### PR TITLE
Backtrack improvements

### DIFF
--- a/Fedoraware/TeamFortress2/TeamFortress2/Features/Aimbot/AimbotHitscan/AimbotHitscan.cpp
+++ b/Fedoraware/TeamFortress2/TeamFortress2/Features/Aimbot/AimbotHitscan/AimbotHitscan.cpp
@@ -377,9 +377,9 @@ bool CAimbotHitscan::VerifyTarget(CBaseEntity* pLocal, CBaseCombatWeapon* pWeapo
 		case ETargetType::PLAYER:
 		{
 			Vec3 hitboxpos;
-			if (Vars::Backtrack::Enabled.Value && Vars::Backtrack::Aim.Value)
+			if (Vars::Backtrack::Enabled.Value && Vars::Backtrack::LastTick.Value)
 			{
-				if (const auto& pLastTick = F::Backtrack.GetTick(target.m_pEntity->GetIndex(), BacktrackMode::Last))
+				if (const auto& pLastTick = F::Backtrack.GetRecord(target.m_pEntity->GetIndex(), BacktrackMode::Last))
 				{
 					if (const auto& pHDR = pLastTick->HDR)
 					{

--- a/Fedoraware/TeamFortress2/TeamFortress2/Features/Aimbot/AimbotMelee/AimbotMelee.cpp
+++ b/Fedoraware/TeamFortress2/TeamFortress2/Features/Aimbot/AimbotMelee/AimbotMelee.cpp
@@ -191,9 +191,9 @@ bool CAimbotMelee::VerifyTarget(CBaseEntity* pLocal, CBaseCombatWeapon* pWeapon,
 	Vec3 hitboxpos;
 
 	// Backtrack the target if required
-	if (Vars::Backtrack::Enabled.Value && Vars::Backtrack::Aim.Value)
+	if (Vars::Backtrack::Enabled.Value && Vars::Backtrack::LastTick.Value)
 	{
-		if (const auto& pLastTick = F::Backtrack.GetTick(target.m_pEntity->GetIndex(), BacktrackMode::Last))
+		if (const auto& pLastTick = F::Backtrack.GetRecord(target.m_pEntity->GetIndex(), BacktrackMode::Last))
 		{
 			if (const auto& pHDR = pLastTick->HDR)
 			{
@@ -228,7 +228,7 @@ bool CAimbotMelee::VerifyTarget(CBaseEntity* pLocal, CBaseCombatWeapon* pWeapon,
 		}
 	}
 	
-	if (Vars::Aimbot::Melee::RangeCheck.Value && !(Vars::Backtrack::Enabled.Value && Vars::Backtrack::Aim.Value))
+	if (Vars::Aimbot::Melee::RangeCheck.Value && !(Vars::Backtrack::Enabled.Value && Vars::Backtrack::LastTick.Value))
 	{
 		if (!CanMeleeHit(pLocal, pWeapon, target.m_vAngleTo, target.m_pEntity->GetIndex()))
 		{
@@ -322,7 +322,7 @@ bool CAimbotMelee::ShouldSwing(CBaseEntity* pLocal, CBaseCombatWeapon* pWeapon, 
 		return false;
 	}
 
-	if (Vars::Backtrack::Enabled.Value && Vars::Backtrack::Aim.Value)
+	if (Vars::Backtrack::Enabled.Value && Vars::Backtrack::LastTick.Value)
 	{
 		const float flRange = pWeapon->GetSwingRange(pLocal);
 

--- a/Fedoraware/TeamFortress2/TeamFortress2/Features/Backtrack/Backtrack.cpp
+++ b/Fedoraware/TeamFortress2/TeamFortress2/Features/Backtrack/Backtrack.cpp
@@ -158,30 +158,15 @@ void CBacktrack::ResetLatency()
 	LatencyRampup = 0.f;
 }
 
-std::deque<TickRecord>* CBacktrack::GetPlayerRecords(int iEntityIndex)
+/* Returns all records of a given player */
+std::deque<TickRecord>* CBacktrack::GetPlayerRecords(int entIdx)
 {
-	if (Records[iEntityIndex].empty())
+	if (Records[entIdx].empty())
 	{
 		return nullptr;
 	}
 
-	return &Records[iEntityIndex];
-}
-
-std::deque<TickRecord>* CBacktrack::GetPlayerRecords(CBaseEntity* pEntity)
-{
-	if (!pEntity)
-	{
-		return nullptr;
-	}
-
-	const auto entindex = pEntity->GetIndex();
-	if (Records[entindex].empty())
-	{
-		return nullptr;
-	}
-
-	return &Records[entindex];
+	return &Records[entIdx];
 }
 
 // Returns the last valid backtrack tick (further away from the player)
@@ -193,7 +178,7 @@ std::optional<TickRecord> CBacktrack::GetLastRecord(int entIdx)
 	return entRecods.back();
 }
 
-// Returns the first valid backtrack tick (close to the player)
+/* Returns the first valid backtrack tick(close to the player) */
 std::optional<TickRecord> CBacktrack::GetFirstRecord(int entIdx)
 {
 	const auto& entRecods = Records[entIdx];
@@ -208,8 +193,8 @@ std::optional<TickRecord> CBacktrack::GetFirstRecord(int entIdx)
 	return std::nullopt;
 }
 
-// Returns the best tick for the chosen mode
-std::optional<TickRecord> CBacktrack::GetTick(int entIdx, BacktrackMode mode)
+/* Returns the best tick for the chosen mode */
+std::optional<TickRecord> CBacktrack::GetRecord(int entIdx, BacktrackMode mode)
 {
 	switch (mode)
 	{

--- a/Fedoraware/TeamFortress2/TeamFortress2/Features/Backtrack/Backtrack.h
+++ b/Fedoraware/TeamFortress2/TeamFortress2/Features/Backtrack/Backtrack.h
@@ -64,9 +64,8 @@ public:
 	//bool IsGoodTick(float simTime);
 	bool IsTickInRange(int tickCount);
 
-	std::deque<TickRecord>* GetPlayerRecords(int iEntityIndex);
-	std::deque<TickRecord>* GetPlayerRecords(CBaseEntity* pEntity);
-	std::optional<TickRecord> GetTick(int entIdx, BacktrackMode mode);
+	std::deque<TickRecord>* GetPlayerRecords(int entIdx);
+	std::optional<TickRecord> GetRecord(int entIdx, BacktrackMode mode);
 
 	bool AllowLatency = false;
 	std::array<std::deque<TickRecord>, 64> Records;

--- a/Fedoraware/TeamFortress2/TeamFortress2/Features/Menu/ConfigManager/ConfigManager.cpp
+++ b/Fedoraware/TeamFortress2/TeamFortress2/Features/Menu/ConfigManager/ConfigManager.cpp
@@ -255,7 +255,7 @@ bool CConfigManager::SaveConfig(const std::string& configName)
 			// Backtrack
 			{
 				SAVE_VAR(Vars::Backtrack::Enabled);
-				SAVE_VAR(Vars::Backtrack::Aim);
+				SAVE_VAR(Vars::Backtrack::LastTick);
 				SAVE_VAR(Vars::Backtrack::Latency);
 				SAVE_VAR(Vars::Backtrack::FakeLatency);
 				//Bt Chams
@@ -1017,7 +1017,7 @@ bool CConfigManager::LoadConfig(const std::string& configName)
 			// Backtrack
 			{
 				LOAD_VAR(Vars::Backtrack::Enabled);
-				LOAD_VAR(Vars::Backtrack::Aim);
+				LOAD_VAR(Vars::Backtrack::LastTick);
 				LOAD_VAR(Vars::Backtrack::Latency);
 				LOAD_VAR(Vars::Backtrack::FakeLatency);
 				//Bt Chams

--- a/Fedoraware/TeamFortress2/TeamFortress2/Features/Menu/Menu.cpp
+++ b/Fedoraware/TeamFortress2/TeamFortress2/Features/Menu/Menu.cpp
@@ -282,7 +282,7 @@ void CMenu::MenuAimbot()
 
 			SectionTitle("Backtrack");
 			WToggle("Active", &Vars::Backtrack::Enabled.Value); HelpMarker("If you shoot at the backtrack manually it will attempt to hit it");
-			WToggle("Aimbot aims last tick", &Vars::Backtrack::Aim.Value); HelpMarker("Aimbot aims at the last tick if visible");
+			WToggle("Aimbot aims last tick", &Vars::Backtrack::LastTick.Value); HelpMarker("Aimbot aims at the last tick if visible");
 			WToggle("Fake latency", &Vars::Backtrack::FakeLatency.Value); HelpMarker("Fakes your latency to hit records further in the past");
 			WSlider("Amount of latency###BTLatency", &Vars::Backtrack::Latency.Value, 200.f, 1000.f, "%.fms", ImGuiSliderFlags_AlwaysClamp | ImGuiSliderFlags_ClampOnInput); HelpMarker("This won't work on local servers");
 		} EndChild();

--- a/Fedoraware/TeamFortress2/TeamFortress2/Features/Vars.h
+++ b/Fedoraware/TeamFortress2/TeamFortress2/Features/Vars.h
@@ -63,7 +63,7 @@ namespace Vars
 	namespace Backtrack
 	{
 		inline CVar<bool> Enabled{ false };
-		inline CVar<bool> Aim{ false };
+		inline CVar<bool> LastTick{ false };
 		inline CVar<bool> FakeLatency{ false };
 		inline CVar<float> Latency{ 200.f };
 

--- a/Fedoraware/TeamFortress2/TeamFortress2/Hooks/Detours/ModelRender_DrawModelExecute.cpp
+++ b/Fedoraware/TeamFortress2/TeamFortress2/Hooks/Detours/ModelRender_DrawModelExecute.cpp
@@ -67,19 +67,26 @@ void DrawBT(void* ecx, void* edx, CBaseEntity* pEntity, const DrawModelState_t& 
 
 				I::RenderView->SetBlend(Color::TOFLOAT(Vars::Backtrack::BtChams::BacktrackColor.a));
 
-				const auto& records = F::Backtrack.Records.at(pEntity->GetIndex());
 				if (Vars::Backtrack::BtChams::LastOnly.Value)
 				{
-					if (!records.empty())
+					const auto& lastRecord = F::Backtrack.GetRecord(pEntity->GetIndex(), BacktrackMode::Last);
+					if (lastRecord)
 					{
-						OriginalFn(ecx, edx, pState, pInfo, (matrix3x4*)(&records.back().BoneMatrix));
+						OriginalFn(ecx, edx, pState, pInfo, (matrix3x4*)(&lastRecord->BoneMatrix));
 					}
 				}
 				else
 				{
-					for (auto& record : records)
+					const auto& entRecords = F::Backtrack.GetPlayerRecords(pEntity->GetIndex());
+					if (entRecords)
 					{
-						OriginalFn(ecx, edx, pState, pInfo, (matrix3x4*)(&record.BoneMatrix));
+						for (auto& record : *entRecords)
+						{
+							if (F::Backtrack.IsTickInRange(record.TickCount))
+							{
+								OriginalFn(ecx, edx, pState, pInfo, (matrix3x4*)(&record.BoneMatrix));
+							}
+						}
 					}
 				}
 


### PR DESCRIPTION
- Auto Backstab can now aim at any valid tick, if "Aim at last tick" is disabled
- Backtrack chams will no longer show out-of-range ticks
- Cleaned up some code