### PR TITLE
B1g changes

### DIFF
--- a/Fedoraware/TeamFortress2/TeamFortress2.vcxproj
+++ b/Fedoraware/TeamFortress2/TeamFortress2.vcxproj
@@ -230,6 +230,7 @@
     <ClCompile Include="TeamFortress2\Hooks\Detours\C_BaseAnimating_Interpolate.cpp" />
     <ClCompile Include="TeamFortress2\Hooks\Detours\C_BaseAnimating_InvalidateBoneCache.cpp" />
     <ClCompile Include="TeamFortress2\Hooks\Detours\C_BaseAnimating_InvalidateBoneCaches.cpp" />
+    <ClCompile Include="TeamFortress2\Hooks\Detours\C_BaseAnimating_MaintainSequenceTransitions.cpp" />
     <ClCompile Include="TeamFortress2\Hooks\Detours\C_BaseAnimating_PushAllowBoneAccess.cpp" />
     <ClCompile Include="TeamFortress2\Hooks\Detours\C_BaseCombatWeapon_AddToCritBucket.cpp" />
     <ClCompile Include="TeamFortress2\Hooks\Detours\CEconItemSchema_GetItemDefinition.cpp" />

--- a/Fedoraware/TeamFortress2/TeamFortress2.vcxproj
+++ b/Fedoraware/TeamFortress2/TeamFortress2.vcxproj
@@ -219,6 +219,7 @@
     <ClCompile Include="TeamFortress2\Hooks\Detours\CInterpolatedVarArrayBase_Interpolate.cpp" />
     <ClCompile Include="TeamFortress2\Hooks\Detours\CInterpolatedVarArrayBase__Extrapolate.cpp" />
     <ClCompile Include="TeamFortress2\Hooks\Detours\CInterpolatedVarArrayBase__Interpolate.cpp" />
+    <ClCompile Include="TeamFortress2\Hooks\Detours\CLagCompensationManager_StartLagCompensation.cpp" />
     <ClCompile Include="TeamFortress2\Hooks\Detours\CL_LatchInterpolationAmount.cpp" />
     <ClCompile Include="TeamFortress2\Hooks\Detours\CNetGraphPanel_DrawTextFields.cpp" />
     <ClCompile Include="TeamFortress2\Hooks\Detours\COcclusionSystem_IsOccluded.cpp" />

--- a/Fedoraware/TeamFortress2/TeamFortress2.vcxproj.filters
+++ b/Fedoraware/TeamFortress2/TeamFortress2.vcxproj.filters
@@ -212,6 +212,7 @@
     <ClCompile Include="TeamFortress2\Hooks\Detours\C_BaseViewModel_ShouldFlipViewModel.cpp" />
     <ClCompile Include="TeamFortress2\Hooks\Detours\FX_FireBullets.cpp" />
     <ClCompile Include="TeamFortress2\Hooks\Detours\CLagCompensationManager_StartLagCompensation.cpp" />
+    <ClCompile Include="TeamFortress2\Hooks\Detours\C_BaseAnimating_MaintainSequenceTransitions.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="TeamFortress2\Features\AutoQueue\AutoQueue.h" />

--- a/Fedoraware/TeamFortress2/TeamFortress2.vcxproj.filters
+++ b/Fedoraware/TeamFortress2/TeamFortress2.vcxproj.filters
@@ -211,6 +211,7 @@
     <ClCompile Include="TeamFortress2\Features\TickHandler\TickHandler.cpp" />
     <ClCompile Include="TeamFortress2\Hooks\Detours\C_BaseViewModel_ShouldFlipViewModel.cpp" />
     <ClCompile Include="TeamFortress2\Hooks\Detours\FX_FireBullets.cpp" />
+    <ClCompile Include="TeamFortress2\Hooks\Detours\CLagCompensationManager_StartLagCompensation.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="TeamFortress2\Features\AutoQueue\AutoQueue.h" />

--- a/Fedoraware/TeamFortress2/TeamFortress2/DLLMain.cpp
+++ b/Fedoraware/TeamFortress2/TeamFortress2/DLLMain.cpp
@@ -5,6 +5,7 @@
 #include "Features/Visuals/Visuals.h"
 #include "Features/Misc/Misc.h"
 #include "Features/Vars.h"
+#include "Features/TickHandler/TickHandler.h"
 
 #include "Features/Menu/Menu.h"
 
@@ -77,6 +78,7 @@ void Initialize()
 
 	g_ConVars.Init();
 	F::LuaEngine.Init();
+	F::Ticks.Reset();
 
 	F::Statistics.m_SteamID = g_SteamInterfaces.User->GetSteamID();
 

--- a/Fedoraware/TeamFortress2/TeamFortress2/Features/Aimbot/AimbotHitscan/AimbotHitscan.cpp
+++ b/Fedoraware/TeamFortress2/TeamFortress2/Features/Aimbot/AimbotHitscan/AimbotHitscan.cpp
@@ -2,29 +2,30 @@
 #include "../../Vars.h"
 #include "../../Backtrack/Backtrack.h"
 
-bool IsHitboxValid(int nHitbox, int index)
+bool IsHitboxValid(int nHitbox, int index, bool bStatic = false)
 {
+	const int iStatic = Vars::Aimbot::Hitscan::StaticHitboxes.Value;
 	switch (nHitbox)
 	{
-	case -1: return true;
-	case HITBOX_HEAD: return (index & (1 << 0));
-	case HITBOX_PELVIS: return (index & (1 << 1));
+//	case -1: return true;
+	case HITBOX_HEAD: return (index & (1 << 0) && !(!bStatic && iStatic & (1 << 0)));
+	case HITBOX_PELVIS: return (index & (1 << 1) && !(!bStatic && iStatic & (1 << 1)));
 	case HITBOX_SPINE_0:
 	case HITBOX_SPINE_1:
 	case HITBOX_SPINE_2:
-	case HITBOX_SPINE_3: return (index & (1 << 2));
+	case HITBOX_SPINE_3: return (index & (1 << 2) && !(!bStatic && iStatic & (1 << 2)));
 	case HITBOX_UPPERARM_L:
 	case HITBOX_LOWERARM_L:
 	case HITBOX_HAND_L:
 	case HITBOX_UPPERARM_R:
 	case HITBOX_LOWERARM_R:
-	case HITBOX_HAND_R: return (index & (1 << 3));
+	case HITBOX_HAND_R: return (index & (1 << 3) && !(!bStatic && iStatic & (1 << 3)));
 	case HITBOX_HIP_L:
 	case HITBOX_KNEE_L:
 	case HITBOX_FOOT_L:
 	case HITBOX_HIP_R:
 	case HITBOX_KNEE_R:
-	case HITBOX_FOOT_R: return (index & (1 << 4));
+	case HITBOX_FOOT_R: return (index & (1 << 4) && !(!bStatic && iStatic & (1 << 4)));
 	}
 	return false;
 };
@@ -305,7 +306,7 @@ bool CAimbotHitscan::ScanHitboxes(CBaseEntity* pLocal, Target_t& target)
 					{
 						for (int nHitbox = -1; nHitbox < target.m_pEntity->GetNumOfHitboxes(); nHitbox++)
 						{
-							if (!IsHitboxValid(nHitbox, Vars::Aimbot::Hitscan::ScanHitboxes.Value)) { continue; }
+							if (!IsHitboxValid(nHitbox, Vars::Aimbot::Hitscan::ScanHitboxes.Value, (target.m_pEntity->GetVelocity().Length() < 10.f))) { continue; }
 							if (nHitbox == -1) { nHitbox = PriorityHitbox; }
 							else if (nHitbox == PriorityHitbox) { continue; }
 
@@ -320,7 +321,7 @@ bool CAimbotHitscan::ScanHitboxes(CBaseEntity* pLocal, Target_t& target)
 								return true;
 							}
 
-							if (IsHitboxValid(nHitbox, Vars::Aimbot::Hitscan::MultiHitboxes.Value))
+							if (IsHitboxValid(nHitbox, Vars::Aimbot::Hitscan::MultiHitboxes.Value, (target.m_pEntity->GetVelocity().Length() < 10.f)))
 							{
 								if (const mstudiobbox_t* pBox = pSet->hitbox(nHitbox))
 								{
@@ -435,11 +436,14 @@ bool CAimbotHitscan::VerifyTarget(CBaseEntity* pLocal, Target_t& target)
 			}
 			if (Vars::Backtrack::Enabled.Value)
 			{
-				if (std::optional<TickRecordNew> ValidRecord = F::BacktrackNew.Aimbot(target.m_pEntity, (BacktrackMode)Vars::Aimbot::Hitscan::BackTrackMethod.Value, GetHitbox(pLocal, pLocal->GetActiveWeapon()))){
-					target.SimTime = ValidRecord->flSimTime;
-					target.m_vAngleTo = Math::CalcAngle(pLocal->GetShootPos(), target.m_pEntity->GetHitboxPosMatrix(GetHitbox(pLocal, pLocal->GetActiveWeapon()), (matrix3x4*)(&ValidRecord->BoneMatrix.BoneMatrix)));
-					target.ShouldBacktrack = true;
-					return true;
+				for (int nHitbox = 0; nHitbox < target.m_pEntity->GetNumOfHitboxes(); nHitbox++){
+					if (!IsHitboxValid(nHitbox, Vars::Aimbot::Hitscan::ScanHitboxes.Value, (target.m_pEntity->GetVelocity().Length() < 10.f))) { continue; }
+					if (std::optional<TickRecordNew> ValidRecord = F::BacktrackNew.Aimbot(target.m_pEntity, (BacktrackMode)Vars::Aimbot::Hitscan::BackTrackMethod.Value, nHitbox)){
+						target.SimTime = ValidRecord->flSimTime;
+						target.m_vAngleTo = Math::CalcAngle(pLocal->GetShootPos(), target.m_pEntity->GetHitboxPosMatrix(nHitbox, (matrix3x4*)(&ValidRecord->BoneMatrix.BoneMatrix)));
+						target.ShouldBacktrack = true;
+						return true;
+					}
 				}
 			}
 			return false;

--- a/Fedoraware/TeamFortress2/TeamFortress2/Features/Aimbot/AimbotHitscan/AimbotHitscan.cpp
+++ b/Fedoraware/TeamFortress2/TeamFortress2/Features/Aimbot/AimbotHitscan/AimbotHitscan.cpp
@@ -444,15 +444,10 @@ bool CAimbotHitscan::VerifyTarget(CBaseEntity* pLocal, Target_t& target)
 						return true;
 					}
 				}
-				target.ShouldBacktrack = false;
 				if (Vars::Backtrack::Latency.Value > 200)
 				{
 					return false;
 				}
-			}
-			else
-			{
-				target.ShouldBacktrack = false;
 			}
 			if (!ScanHitboxes(pLocal, target))
 			{

--- a/Fedoraware/TeamFortress2/TeamFortress2/Features/Aimbot/AimbotHitscan/AimbotHitscan.cpp
+++ b/Fedoraware/TeamFortress2/TeamFortress2/Features/Aimbot/AimbotHitscan/AimbotHitscan.cpp
@@ -432,11 +432,11 @@ bool CAimbotHitscan::VerifyTarget(CBaseEntity* pLocal, Target_t& target)
 			Vec3 hitboxpos;
 			if (Vars::Backtrack::Enabled.Value && Vars::Backtrack::LastTick.Value)
 			{
-				TickRecordNew pLastTick = F::BacktrackNew.Run(nullptr, true, target.m_pEntity);
-				if (pLastTick.flSimTime > target.m_pEntity->GetSimulationTime() - 1.f && pLastTick.flCreateTime > I::GlobalVars->curtime - 1.f)
+				const auto& vLastRec = F::BacktrackNew.GetRecord(target.m_pEntity, BacktrackMode::Last);
+				if (vLastRec)
 				{
-					hitboxpos = target.m_pEntity->GetHitboxPosMatrix(HITBOX_HEAD, reinterpret_cast<matrix3x4*>(&pLastTick.BoneMatrix));
-					target.SimTime = pLastTick.flSimTime;
+					hitboxpos = target.m_pEntity->GetHitboxPosMatrix(HITBOX_HEAD, (matrix3x4*)(&vLastRec->BoneMatrix.BoneMatrix));
+					target.SimTime = vLastRec->flSimTime;
 					if (Utils::VisPos(pLocal, target.m_pEntity, pLocal->GetShootPos(), hitboxpos))
 					{
 						target.m_vAngleTo = Math::CalcAngle(pLocal->GetShootPos(), hitboxpos);

--- a/Fedoraware/TeamFortress2/TeamFortress2/Features/Aimbot/AimbotHitscan/AimbotHitscan.cpp
+++ b/Fedoraware/TeamFortress2/TeamFortress2/Features/Aimbot/AimbotHitscan/AimbotHitscan.cpp
@@ -435,7 +435,7 @@ bool CAimbotHitscan::VerifyTarget(CBaseEntity* pLocal, Target_t& target)
 				const auto& vLastRec = F::BacktrackNew.Run(nullptr, true, target.m_pEntity);
 				if (vLastRec)
 				{
-					hitboxpos = target.m_pEntity->GetHitboxPosMatrix(HITBOX_HEAD, (matrix3x4*)(&vLastRec->BoneMatrix.BoneMatrix));
+					hitboxpos = target.m_pEntity->GetHitboxPosMatrix(GetHitbox(pLocal, pLocal->GetActiveWeapon()), (matrix3x4*)(&vLastRec->BoneMatrix.BoneMatrix));
 					target.SimTime = vLastRec->flSimTime;
 					if (Utils::VisPos(pLocal, target.m_pEntity, pLocal->GetShootPos(), hitboxpos))
 					{

--- a/Fedoraware/TeamFortress2/TeamFortress2/Features/Aimbot/AimbotHitscan/AimbotHitscan.cpp
+++ b/Fedoraware/TeamFortress2/TeamFortress2/Features/Aimbot/AimbotHitscan/AimbotHitscan.cpp
@@ -7,7 +7,7 @@ bool IsHitboxValid(int nHitbox, int index, bool bStatic = false)
 	const int iStatic = Vars::Aimbot::Hitscan::StaticHitboxes.Value;
 	switch (nHitbox)
 	{
-//	case -1: return true;
+	case -1: return true;
 	case HITBOX_HEAD: return (index & (1 << 0) && !(!bStatic && iStatic & (1 << 0)));
 	case HITBOX_PELVIS: return (index & (1 << 1) && !(!bStatic && iStatic & (1 << 1)));
 	case HITBOX_SPINE_0:
@@ -901,7 +901,9 @@ void CAimbotHitscan::Run(CBaseEntity* pLocal, CBaseCombatWeapon* pWeapon, CUserC
 		if ((Vars::Misc::DisableInterpolation.Value && target.m_TargetType == ETargetType::PLAYER && bIsAttacking) ||
 			target.ShouldBacktrack)
 		{
+			Utils::ConLog("Aimbot", tfm::format("Old pCmd->tick_count {%d}", pCmd->tick_count).c_str(), {126, 0, 255, 255});
 			pCmd->tick_count = TIME_TO_TICKS(tickCount + simTime);
+			Utils::ConLog("Aimbot", tfm::format("Set pCmd->tickcount to {%d | <%.1f | %.1f | %.1f>}", pCmd->tick_count, TICKS_TO_TIME(pCmd->tick_count), simTime, tickCount).c_str(), {126, 0, 255, 255});
 		}
 
 		Aim(pCmd, target.m_vAngleTo);

--- a/Fedoraware/TeamFortress2/TeamFortress2/Features/Aimbot/AimbotHitscan/AimbotHitscan.cpp
+++ b/Fedoraware/TeamFortress2/TeamFortress2/Features/Aimbot/AimbotHitscan/AimbotHitscan.cpp
@@ -901,9 +901,7 @@ void CAimbotHitscan::Run(CBaseEntity* pLocal, CBaseCombatWeapon* pWeapon, CUserC
 		if ((Vars::Misc::DisableInterpolation.Value && target.m_TargetType == ETargetType::PLAYER && bIsAttacking) ||
 			target.ShouldBacktrack)
 		{
-			Utils::ConLog("Aimbot", tfm::format("Old pCmd->tick_count {%d}", pCmd->tick_count).c_str(), {126, 0, 255, 255});
 			pCmd->tick_count = TIME_TO_TICKS(tickCount + simTime);
-			Utils::ConLog("Aimbot", tfm::format("Set pCmd->tickcount to {%d | <%.1f | %.1f | %.1f>}", pCmd->tick_count, TICKS_TO_TIME(pCmd->tick_count), simTime, tickCount).c_str(), {126, 0, 255, 255});
 		}
 
 		Aim(pCmd, target.m_vAngleTo);

--- a/Fedoraware/TeamFortress2/TeamFortress2/Features/Aimbot/AimbotHitscan/AimbotHitscan.cpp
+++ b/Fedoraware/TeamFortress2/TeamFortress2/Features/Aimbot/AimbotHitscan/AimbotHitscan.cpp
@@ -429,7 +429,7 @@ bool CAimbotHitscan::VerifyTarget(CBaseEntity* pLocal, Target_t& target)
 	{
 	case ETargetType::PLAYER:
 		{
-			if (ScanHitboxes(pLocal, target) && !((Vars::Backtrack::Enabled.Value && Vars::Backtrack::Latency.Value > 200) || G::ChokeMap[target.m_pEntity->GetIndex()] > Vars::Aimbot::Global::TickTolerance.Value || Vars::Aimbot::Hitscan::BackTrackMethod.Value == 4))
+			if (ScanHitboxes(pLocal, target) && !((F::BacktrackNew.bFakeLatency && Vars::Backtrack::Latency.Value > 200) || G::ChokeMap[target.m_pEntity->GetIndex()] > Vars::Aimbot::Global::TickTolerance.Value || Vars::Aimbot::Hitscan::BackTrackMethod.Value == 4))
 			{
 				return true;
 			}

--- a/Fedoraware/TeamFortress2/TeamFortress2/Features/Aimbot/AimbotHitscan/AimbotHitscan.cpp
+++ b/Fedoraware/TeamFortress2/TeamFortress2/Features/Aimbot/AimbotHitscan/AimbotHitscan.cpp
@@ -429,38 +429,28 @@ bool CAimbotHitscan::VerifyTarget(CBaseEntity* pLocal, Target_t& target)
 	{
 	case ETargetType::PLAYER:
 		{
-		//	if we failed to scan hitboxes for the player at curtime, or, if the player is unsimulated at curtime, or if we cant hit the curtime record due to latency, do backtrack.
-		if ((!ScanHitboxes(pLocal, target) && (Vars::Backtrack::Enabled.Value && Vars::Backtrack::Latency.Value > (200.f - I::GlobalVars->interval_per_tick))) || (G::ChokeMap[target.m_pEntity->GetIndex()] > Vars::Aimbot::Global::TickTolerance.Value))
+			if (ScanHitboxes(pLocal, target) && !((Vars::Backtrack::Enabled.Value && Vars::Backtrack::Latency.Value > (200.f - I::GlobalVars->interval_per_tick)) || G::ChokeMap[target.m_pEntity->GetIndex()] > Vars::Aimbot::Global::TickTolerance.Value))
 			{
-				if (Vars::Backtrack::Enabled.Value && Vars::Backtrack::LastTick.Value)
+				return true;
+			}
+			if (Vars::Backtrack::Enabled.Value && Vars::Backtrack::LastTick.Value)
+			{
+				Vec3 hitboxpos;
+				const auto& vLastRec = F::BacktrackNew.Run(nullptr, true, target.m_pEntity);
+				if (vLastRec)
 				{
-					Vec3 hitboxpos;
-					const auto& vLastRec = F::BacktrackNew.Run(nullptr, true, target.m_pEntity);
-					if (vLastRec)
+					hitboxpos = target.m_pEntity->GetHitboxPosMatrix(GetHitbox(pLocal, pLocal->GetActiveWeapon()), (matrix3x4*)(&vLastRec->BoneMatrix.BoneMatrix));
+					target.SimTime = vLastRec->flSimTime;
+					if (Utils::VisPos(pLocal, target.m_pEntity, pLocal->GetShootPos(), hitboxpos))
 					{
-						hitboxpos = target.m_pEntity->GetHitboxPosMatrix(GetHitbox(pLocal, pLocal->GetActiveWeapon()), (matrix3x4*)(&vLastRec->BoneMatrix.BoneMatrix));
-						target.SimTime = vLastRec->flSimTime;
-						if (Utils::VisPos(pLocal, target.m_pEntity, pLocal->GetShootPos(), hitboxpos))
-						{
-							target.m_vAngleTo = Math::CalcAngle(pLocal->GetShootPos(), hitboxpos);
-							target.ShouldBacktrack = true;
-							return true;
-						}
+						target.m_vAngleTo = Math::CalcAngle(pLocal->GetShootPos(), hitboxpos);
+						target.ShouldBacktrack = true;
+						return true;
 					}
 				}
-				return false;
 			}
-
-			//	we failed to target this player due to !ScaHitboxes or the player being unsimulated, as well as backtrack failing to get a viable record
-			if (Vars::Aimbot::Global::IgnoreOptions.Value & (UNSIMULATED)){
-				if (G::ChokeMap[target.m_pEntity->GetIndex()] > Vars::Aimbot::Global::TickTolerance.Value){
-					return false;
-				}
-			}
-
-			break;
+			return false;
 		}
-
 	case ETargetType::BUILDING:
 		{
 			if (!Utils::VisPos(pLocal, target.m_pEntity, pLocal->GetShootPos(), target.m_vPos))

--- a/Fedoraware/TeamFortress2/TeamFortress2/Features/Aimbot/AimbotHitscan/AimbotHitscan.cpp
+++ b/Fedoraware/TeamFortress2/TeamFortress2/Features/Aimbot/AimbotHitscan/AimbotHitscan.cpp
@@ -432,7 +432,7 @@ bool CAimbotHitscan::VerifyTarget(CBaseEntity* pLocal, Target_t& target)
 			Vec3 hitboxpos;
 			if (Vars::Backtrack::Enabled.Value && Vars::Backtrack::LastTick.Value)
 			{
-				const auto& vLastRec = F::BacktrackNew.GetRecord(target.m_pEntity, BacktrackMode::Last);
+				const auto& vLastRec = F::BacktrackNew.Run(nullptr, true, target.m_pEntity);
 				if (vLastRec)
 				{
 					hitboxpos = target.m_pEntity->GetHitboxPosMatrix(HITBOX_HEAD, (matrix3x4*)(&vLastRec->BoneMatrix.BoneMatrix));

--- a/Fedoraware/TeamFortress2/TeamFortress2/Features/Aimbot/AimbotHitscan/AimbotHitscan.cpp
+++ b/Fedoraware/TeamFortress2/TeamFortress2/Features/Aimbot/AimbotHitscan/AimbotHitscan.cpp
@@ -444,11 +444,10 @@ bool CAimbotHitscan::VerifyTarget(CBaseEntity* pLocal, Target_t& target)
 						return true;
 					}
 				}
-				if (Vars::Backtrack::Latency.Value > 200)
-				{
-					return false;
-				}
+				if (Vars::Backtrack::Latency.Value > (200.f - I::GlobalVars->interval_per_tick) )
+				{ return false; }
 			}
+
 			if (!ScanHitboxes(pLocal, target))
 			{
 				return false;

--- a/Fedoraware/TeamFortress2/TeamFortress2/Features/Aimbot/AimbotHitscan/AimbotHitscan.cpp
+++ b/Fedoraware/TeamFortress2/TeamFortress2/Features/Aimbot/AimbotHitscan/AimbotHitscan.cpp
@@ -433,19 +433,17 @@ bool CAimbotHitscan::VerifyTarget(CBaseEntity* pLocal, Target_t& target)
 			if (Vars::Backtrack::Enabled.Value && Vars::Backtrack::LastTick.Value)
 			{
 				TickRecordNew pLastTick = F::BacktrackNew.Run(nullptr, true, target.m_pEntity);
-				if (pLastTick.flSimTime != 0.f)
+				if (pLastTick.flSimTime > target.m_pEntity->GetSimulationTime() - 1.f && pLastTick.flCreateTime > I::GlobalVars->curtime - 1.f)
 				{
-					hitboxpos = target.m_pEntity->GetHitboxPosMatrix(HITBOX_HEAD, reinterpret_cast<matrix3x4*>(&pLastTick.BoneMatrix.BoneMatrix));
+					hitboxpos = target.m_pEntity->GetHitboxPosMatrix(HITBOX_HEAD, reinterpret_cast<matrix3x4*>(&pLastTick.BoneMatrix));
 					target.SimTime = pLastTick.flSimTime;
+					if (Utils::VisPos(pLocal, target.m_pEntity, pLocal->GetShootPos(), hitboxpos))
+					{
+						target.m_vAngleTo = Math::CalcAngle(pLocal->GetShootPos(), hitboxpos);
+						target.ShouldBacktrack = true;
+						return true;
+					}
 				}
-
-				if (Utils::VisPos(pLocal, target.m_pEntity, pLocal->GetShootPos(), hitboxpos))
-				{
-					target.m_vAngleTo = Math::CalcAngle(pLocal->GetShootPos(), hitboxpos);
-					target.ShouldBacktrack = true;
-					return true;
-				}
-
 				target.ShouldBacktrack = false;
 				if (Vars::Backtrack::Latency.Value > 200)
 				{

--- a/Fedoraware/TeamFortress2/TeamFortress2/Features/Aimbot/AimbotMelee/AimbotMelee.cpp
+++ b/Fedoraware/TeamFortress2/TeamFortress2/Features/Aimbot/AimbotMelee/AimbotMelee.cpp
@@ -237,7 +237,7 @@ bool CAimbotMelee::VerifyTarget(CBaseEntity* pLocal, CBaseCombatWeapon* pWeapon,
 				target.ShouldBacktrack = true;
 			}
 		}
-		if (Vars::Backtrack::Latency.Value > 200.f && !target.ShouldBacktrack) // Check if the player is in range for a non-backtrack hit
+		if (F::BacktrackNew.bFakeLatency && Vars::Backtrack::Latency.Value > 200.f && !target.ShouldBacktrack) // Check if the player is in range for a non-backtrack hit
 		{ return false; }
 	}
 

--- a/Fedoraware/TeamFortress2/TeamFortress2/Features/Aimbot/AimbotMelee/AimbotMelee.cpp
+++ b/Fedoraware/TeamFortress2/TeamFortress2/Features/Aimbot/AimbotMelee/AimbotMelee.cpp
@@ -235,10 +235,12 @@ bool CAimbotMelee::VerifyTarget(CBaseEntity* pLocal, CBaseCombatWeapon* pWeapon,
 				target.m_vPos = hitboxpos;
 				target.ShouldBacktrack = true;
 			}
-			else if (Vars::Backtrack::Latency.Value > 200 && !target.ShouldBacktrack) // Check if the player is in range for a non-backtrack hit
-			{ return false; }
 		}
+		if (Vars::Backtrack::Latency.Value > (200.f - I::GlobalVars->interval_per_tick) && !target.ShouldBacktrack) // Check if the player is in range for a non-backtrack hit
+		{ return false; }
 	}
+
+
 
 	if (Vars::Aimbot::Melee::RangeCheck.Value && !(Vars::Backtrack::Enabled.Value && Vars::Backtrack::LastTick.Value))
 	{

--- a/Fedoraware/TeamFortress2/TeamFortress2/Features/Aimbot/AimbotMelee/AimbotMelee.cpp
+++ b/Fedoraware/TeamFortress2/TeamFortress2/Features/Aimbot/AimbotMelee/AimbotMelee.cpp
@@ -221,43 +221,24 @@ bool CAimbotMelee::VerifyTarget(CBaseEntity* pLocal, CBaseCombatWeapon* pWeapon,
 {
 	Vec3 hitboxpos;
 
-	// Backtrack the target if required
-	//if (Vars::Backtrack::Enabled.Value && Vars::Backtrack::LastTick.Value && target.m_TargetType == ETargetType::PLAYER)
-	//{
-	//	if (const auto& pLastTick = F::Backtrack.GetRecord(target.m_pEntity->GetIndex(), BacktrackMode::Last))
-	//	{
-	//		if (const auto& pHDR = pLastTick->HDR)
-	//		{
-	//			if (const auto& pSet = pHDR->GetHitboxSet(pLastTick->HitboxSet))
-	//			{
-	//				if (const auto& pBox = pSet->hitbox(HITBOX_PELVIS))
-	//				{
-	//					const Vec3 vPos = (pBox->bbmin + pBox->bbmax) * 0.5f;
-	//					Vec3 vOut;
-	//					const matrix3x4& bone = pLastTick->BoneMatrix.BoneMatrix[pBox->bone];
-	//					Math::VectorTransform(vPos, bone, vOut);
-	//					hitboxpos = vOut;
-	//					target.SimTime = pLastTick->SimulationTime;
-	//				}
-	//			}
-	//		}
-	//	}
-	//
-	//	// Check if the backtrack pos is visible
-	//	if (Utils::VisPos(pLocal, target.m_pEntity, pLocal->GetShootPos(), hitboxpos))
-	//	{
-	//		target.m_vAngleTo = Math::CalcAngle(pLocal->GetShootPos(), hitboxpos);
-	//		target.m_vPos = hitboxpos;
-	//		target.ShouldBacktrack = true;
-	//		return true;
-	//	}
-	//
-	//	// Check if the player is in range for a non-backtrack hit
-	//	if (Vars::Backtrack::Latency.Value > 200)
-	//	{
-	//		return false;
-	//	}
-	//}
+	//Backtrack the target if required
+	if (Vars::Backtrack::Enabled.Value && Vars::Backtrack::LastTick.Value && target.m_TargetType == ETargetType::PLAYER)
+	{
+		const auto& record = F::BacktrackNew.GetLastRecord(target.m_pEntity);
+		if (record) {
+			hitboxpos = target.m_pEntity->GetHitboxPosMatrix(HITBOX_PELVIS, (matrix3x4*)(&record->BoneMatrix));
+			target.SimTime = record->flSimTime;
+
+			// Check if the backtrack pos is visible
+			if (Utils::VisPos(pLocal, target.m_pEntity, pLocal->GetShootPos(), hitboxpos)) {
+				target.m_vAngleTo = Math::CalcAngle(pLocal->GetShootPos(), hitboxpos);
+				target.m_vPos = hitboxpos;
+				target.ShouldBacktrack = true;
+			}
+			else if (Vars::Backtrack::Latency.Value > 200 && !target.ShouldBacktrack) // Check if the player is in range for a non-backtrack hit
+			{ return false; }
+		}
+	}
 
 	if (Vars::Aimbot::Melee::RangeCheck.Value && !(Vars::Backtrack::Enabled.Value && Vars::Backtrack::LastTick.Value))
 	{
@@ -354,7 +335,7 @@ bool CAimbotMelee::ShouldSwing(CBaseEntity* pLocal, CBaseCombatWeapon* pWeapon, 
 	{
 		const float flRange = pWeapon->GetSwingRange(pLocal);
 
-		if (Target.m_vPos.DistTo(pLocal->GetShootPos()) > flRange * 1.9f) // It just works?
+		if (Target.m_vPos.DistTo(pLocal->GetShootPos()) > flRange) // why was this being multiplied.
 		{
 			//I::DebugOverlay->AddLineOverlay(Target.m_vPos, pLocal->GetShootPos(), 255, 0, 0, false, 1.f);
 			return false;

--- a/Fedoraware/TeamFortress2/TeamFortress2/Features/Aimbot/AimbotMelee/AimbotMelee.cpp
+++ b/Fedoraware/TeamFortress2/TeamFortress2/Features/Aimbot/AimbotMelee/AimbotMelee.cpp
@@ -223,7 +223,7 @@ bool CAimbotMelee::VerifyTarget(CBaseEntity* pLocal, CBaseCombatWeapon* pWeapon,
 	Vec3 hitboxpos;
 
 	//Backtrack the target if required
-	if (Vars::Backtrack::Enabled.Value && Vars::Backtrack::LastTick.Value && target.m_TargetType == ETargetType::PLAYER)
+	if (Vars::Backtrack::Enabled.Value && target.m_TargetType == ETargetType::PLAYER)
 	{
 		const auto& record = F::BacktrackNew.GetLastRecord(target.m_pEntity);
 		if (record) {
@@ -243,7 +243,7 @@ bool CAimbotMelee::VerifyTarget(CBaseEntity* pLocal, CBaseCombatWeapon* pWeapon,
 
 
 
-	if (Vars::Aimbot::Melee::RangeCheck.Value && !(Vars::Backtrack::Enabled.Value && Vars::Backtrack::LastTick.Value))
+	if (Vars::Aimbot::Melee::RangeCheck.Value && !(Vars::Backtrack::Enabled.Value))
 	{
 		if (!CanMeleeHit(pLocal, pWeapon, target.m_vAngleTo, target.m_pEntity->GetIndex()))
 		{
@@ -334,7 +334,7 @@ bool CAimbotMelee::ShouldSwing(CBaseEntity* pLocal, CBaseCombatWeapon* pWeapon, 
 		return false;
 	}
 
-	if (Vars::Backtrack::Enabled.Value && Vars::Backtrack::LastTick.Value)
+	if (Vars::Backtrack::Enabled.Value)
 	{
 		const float flRange = pWeapon->GetSwingRange(pLocal);
 

--- a/Fedoraware/TeamFortress2/TeamFortress2/Features/AntiHack/AntiAim.cpp
+++ b/Fedoraware/TeamFortress2/TeamFortress2/Features/AntiHack/AntiAim.cpp
@@ -211,7 +211,7 @@ void CAntiAim::Run(CUserCmd* pCmd, bool* pSendPacket)
 
 	// Manual yaw key
 	static KeyHelper kManual(&Vars::AntiHack::AntiAim::ManualKey.Value);
-	bManualing = kManual.Down();
+	bManualing = kManual.Down() && (Vars::AntiHack::AntiAim::YawFake.Value == 14 || Vars::AntiHack::AntiAim::YawReal.Value == 14);
 
 	if (!Vars::AntiHack::AntiAim::Active.Value || G::ForceSendPacket || G::AvoidingBackstab || G::ShouldShift) { return; }
 

--- a/Fedoraware/TeamFortress2/TeamFortress2/Features/AntiHack/AntiAim.cpp
+++ b/Fedoraware/TeamFortress2/TeamFortress2/Features/AntiHack/AntiAim.cpp
@@ -110,9 +110,6 @@ bool CAntiAim::FindEdge(float edgeOrigYaw)
 	if (edgeLeftDist >= 260) { edgeLeftDist = 999999999.f; }
 	if (edgeRightDist >= 260) { edgeRightDist = 999999999.f; }
 
-	// If none of the vectors found a wall, then dont edge
-	if (Utils::CompareFloat(edgeLeftDist, edgeRightDist)) { return false; }
-
 	// Depending on the edge, choose a direction to face
 	bEdge = edgeRightDist < edgeLeftDist;
 	if (G::RealViewAngles.x == 89.f) // Check for real up
@@ -120,7 +117,7 @@ bool CAntiAim::FindEdge(float edgeOrigYaw)
 		bEdge = !bEdge;
 	}
 
-	return true;
+	return bEdge;
 }
 
 bool CAntiAim::IsOverlapping(float epsilon = 45.f)
@@ -189,7 +186,7 @@ float CAntiAim::GetBaseYaw(int iMode, CBaseEntity* pLocal, CUserCmd* pCmd){
 			
 			if (flFOVTo < flSmallestFovTo) { flSmallestAngleTo = vAngleTo.y; flSmallestFovTo = flFOVTo; }
 		}
-		return (flSmallestFovTo == 360.f ? pCmd->viewangles.y + (iMode == 2 ? flBaseOffset : 0) : flSmallestAngleTo + + (iMode == 2 ? flBaseOffset : 0));
+		return (flSmallestFovTo == 360.f ? pCmd->viewangles.y + (iMode == 2 ? flBaseOffset : 0) : flSmallestAngleTo + (iMode == 2 ? flBaseOffset : 0));
 	}
 	}
 	return pCmd->viewangles.y;

--- a/Fedoraware/TeamFortress2/TeamFortress2/Features/AntiHack/AntiAim.h
+++ b/Fedoraware/TeamFortress2/TeamFortress2/Features/AntiHack/AntiAim.h
@@ -10,7 +10,6 @@ private:
 
 	// logic
 	float EdgeDistance(float edgeRayYaw);
-	bool FindEdge(float edgeOrigYaw);
 	bool IsOverlapping(float epsilon);
 	bool ShouldAntiAim(CBaseEntity* pLocal);
 	
@@ -37,6 +36,7 @@ private:
 
 	Timer tAATimer{};
 public:
+	bool FindEdge(float edgeOrigYaw);
 	void Run(CUserCmd* pCmd, bool* pSendPacket);
 	void Event(CGameEvent* pEvent, const FNV1A_t uNameHash);
 	void Draw(CBaseEntity* pLocal);

--- a/Fedoraware/TeamFortress2/TeamFortress2/Features/AntiHack/CheaterDetection/CheaterDetection.cpp
+++ b/Fedoraware/TeamFortress2/TeamFortress2/Features/AntiHack/CheaterDetection/CheaterDetection.cpp
@@ -125,9 +125,9 @@ void CCheaterDetection::OnTick()
 		if (CheckBHop(pEntity)) { bMarked = true; Utils::ConLog("CheaterDetection", tfm::format("%s infracted for bunny-hopping.", pInfo.name).c_str(), {224, 255, 131, 255}); }
 
 		//analytical analysis
-		if ((mData[pEntity].pChoke.second / mData[pEntity].pChoke.first) > (14.f / server.flMultiplier) && mData[pEntity].pChoke.first > 10) { mData[pEntity].iPlayerSuspicion++; Utils::ConLog("CheaterDetection", tfm::format("%s infracted for high avg packet choking {%.1f / %.1f}.", pInfo.name, mData[pEntity].pChoke.second, (14.f / server.flMultiplier)).c_str(), { 224, 255, 131, 255 }); mData[pEntity].pChoke = { 0, 0.f }; }
-		if (mData[pEntity].flHitchance > (server.flQ2 + server.flQ3 * 1.6) && !mData[pEntity].pDetections.first && flScanningTime > 120.f) { mData[pEntity].iPlayerSuspicion += 5; Utils::ConLog("CheaterDetection", tfm::format("%s infracted for extremely high accuracy {%.1f / %.1f}.", pInfo.name, mData[pEntity].flHitchance, (server.flQ2 + server.flQ3 * 1.6)).c_str(), {224, 255, 131, 255}); }
-		if (mData[pEntity].flScorePerSecond > (server.flAverageScorePerSecond * 3) && !mData[pEntity].pDetections.second && flScanningTime > 10.f) { mData[pEntity].iPlayerSuspicion += 5; Utils::ConLog("CheaterDetection", tfm::format("%s infracted for extremely high score per second {%.1f / %.1f}.", pInfo.name, mData[pEntity].flScorePerSecond, server.flAverageScorePerSecond).c_str(), {224, 255, 131, 255}); }
+		if (mData[pEntity].pChoke.second && mData[pEntity].pChoke.first) { if ((mData[pEntity].pChoke.second / mData[pEntity].pChoke.first) > (14.f / server.flMultiplier) && mData[pEntity].pChoke.first > 10) { mData[pEntity].iPlayerSuspicion++; Utils::ConLog("CheaterDetection", tfm::format("%s infracted for high avg packet choking {%.1f / %.1f}.", pInfo.name, mData[pEntity].pChoke.second, (14.f / server.flMultiplier)).c_str(), { 224, 255, 131, 255 }); mData[pEntity].pChoke = { 0, 0.f }; } }
+		if (mData[pEntity].flHitchance && server.flQ2) { if (mData[pEntity].flHitchance > (server.flQ2 + server.flQ3 * 1.6) && !mData[pEntity].pDetections.first && flScanningTime > 120.f) { mData[pEntity].iPlayerSuspicion += 5; Utils::ConLog("CheaterDetection", tfm::format("%s infracted for extremely high accuracy {%.1f / %.1f}.", pInfo.name, mData[pEntity].flHitchance, (server.flQ2 + server.flQ3 * 1.6)).c_str(), {224, 255, 131, 255}); } }
+		if (mData[pEntity].flScorePerSecond && server.flAverageScorePerSecond) { if (mData[pEntity].flScorePerSecond > (server.flAverageScorePerSecond * 3) && !mData[pEntity].pDetections.second && flScanningTime > 10.f) { mData[pEntity].iPlayerSuspicion += 5; Utils::ConLog("CheaterDetection", tfm::format("%s infracted for extremely high score per second {%.1f / %.1f}.", pInfo.name, mData[pEntity].flScorePerSecond, server.flAverageScorePerSecond).c_str(), {224, 255, 131, 255}); } }
 	}
 }
 
@@ -167,6 +167,8 @@ void CCheaterDetection::FindHitchances(){	//	runs every 20 seconds
 	if (I::GlobalVars->curtime - flLastAccuracyTime < 20.f) { return; }
 	flLastAccuracyTime = I::GlobalVars->curtime;
 
+	if (server.mAccuracies.size() < 1) { return; }
+
 	std::vector<float> vUnsorted{};
 	std::map<CBaseEntity*, float>::iterator iter = server.mAccuracies.begin();
 	while (iter != server.mAccuracies.end()){
@@ -205,6 +207,7 @@ void CCheaterDetection::Reset(){
 void CCheaterDetection::OnLoad(){
 	Reset();
 	FillServerInfo();
+	flLastAccuracyTime = I::GlobalVars->curtime; flLastScoreTime = I::GlobalVars->curtime;
 }
 
 void CCheaterDetection::CalculateHitChance(CBaseEntity* pEntity){

--- a/Fedoraware/TeamFortress2/TeamFortress2/Features/AntiHack/CheaterDetection/CheaterDetection.cpp
+++ b/Fedoraware/TeamFortress2/TeamFortress2/Features/AntiHack/CheaterDetection/CheaterDetection.cpp
@@ -71,10 +71,10 @@ void CCheaterDetection::ReportTickCount(std::pair<CBaseEntity*, int> pReport){
 bool CCheaterDetection::CheckBHop(CBaseEntity* pEntity){
 	const bool bOnGround = pEntity->OnSolid();	//	NOTE: groundentity isn't networked properly sometimes i think
 	if (bOnGround) { mData[pEntity].pBhop.first++; }
-	else if (mData[pEntity].pBhop.first <= Vars::Misc::CheaterDetection::BHopMaxDelay.Value) { mData[pEntity].pBhop.second++; mData[pEntity].pBhop.first = 0; }
+	else if (mData[pEntity].pBhop.first <= Vars::Misc::CheaterDetection::BHopMaxDelay.Value && mData[pEntity].pBhop.first > 0) { mData[pEntity].pBhop.second++; mData[pEntity].pBhop.first = 0; }
 	else { mData[pEntity].pBhop = {0, 0}; }
 
-	if (mData[pEntity].pBhop.second > Vars::Misc::CheaterDetection::BHopDetectionsRequired.Value) { mData[pEntity].iPlayerSuspicion++; mData[pEntity].pBhop = {0, 0}; return true; }
+	if (mData[pEntity].pBhop.second >= Vars::Misc::CheaterDetection::BHopDetectionsRequired.Value) { mData[pEntity].iPlayerSuspicion++; mData[pEntity].pBhop = {0, 0}; return true; }
 	return false;
 }
 

--- a/Fedoraware/TeamFortress2/TeamFortress2/Features/AntiHack/CheaterDetection/CheaterDetection.cpp
+++ b/Fedoraware/TeamFortress2/TeamFortress2/Features/AntiHack/CheaterDetection/CheaterDetection.cpp
@@ -146,7 +146,7 @@ void CCheaterDetection::OnTick()
 
 		const Vec3 vAngles = pEntity->GetEyeAngles();
 		mData[pEntity].vLastAngle = {vAngles.x, vAngles.y};
-		if (mData[pEntity].iPlayerSuspicion > INT_MAX_SUSPICION) { mData[pEntity].iPlayerSuspicion = 0; G::PlayerPriority[pInfo.friendsID].Mode = 4; }
+		if (mData[pEntity].iPlayerSuspicion >= INT_MAX_SUSPICION) { mData[pEntity].iPlayerSuspicion = 0; G::PlayerPriority[pInfo.friendsID].Mode = 4; }
 	}
 }
 
@@ -187,7 +187,7 @@ void CCheaterDetection::FindHitchances(){	//	runs every 30 seconds
 	const float flAvg = (float)server.iHits / (float)server.iMisses;
 	server.flHighAccuracy = std::clamp(flAvg * 2, .05f, .95f);
 
-	Utils::ConLog("CheaterDetection[UTIL]", tfm::format("Calculated server hitchance data {%.1f | %.1f}", flAvg, server.flHighAccuracy).c_str(), {224, 255, 131, 255});
+	Utils::ConLog("CheaterDetection[UTIL]", tfm::format("Calculated server hitchance data {%.5f | %.5f}", flAvg, server.flHighAccuracy).c_str(), {224, 255, 131, 255});
 }
 
 void CCheaterDetection::Reset(){

--- a/Fedoraware/TeamFortress2/TeamFortress2/Features/AntiHack/CheaterDetection/CheaterDetection.cpp
+++ b/Fedoraware/TeamFortress2/TeamFortress2/Features/AntiHack/CheaterDetection/CheaterDetection.cpp
@@ -214,6 +214,8 @@ void CCheaterDetection::ReportDamage(CGameEvent* pEvent){
 	const int iIndex = pEvent->GetInt("attacker");
 	CBaseEntity* pEntity = I::ClientEntityList->GetClientEntity(iIndex);
 	if (!pEntity || pEntity->GetDormant()){ return; }
+	CBaseCombatWeapon* pWeapon = pEntity->GetActiveWeapon();
+	if (!pWeapon || Utils::GetWeaponType(pWeapon) != EWeaponType::HITSCAN) { return; }
 	if (I::GlobalVars->tickcount - mData[pEntity].iLastDamageEventTick <= 1){ return; }
 	mData[pEntity].iLastDamageEventTick = I::GlobalVars->tickcount;
 	mData[pEntity].mShots.first++;

--- a/Fedoraware/TeamFortress2/TeamFortress2/Features/AntiHack/CheaterDetection/CheaterDetection.cpp
+++ b/Fedoraware/TeamFortress2/TeamFortress2/Features/AntiHack/CheaterDetection/CheaterDetection.cpp
@@ -126,7 +126,7 @@ void CCheaterDetection::OnTick()
 
 		//analytical analysis
 		if (mData[pEntity].pChoke.second && mData[pEntity].pChoke.first) { if ((mData[pEntity].pChoke.second / mData[pEntity].pChoke.first) > (14.f / server.flMultiplier) && mData[pEntity].pChoke.first > 10) { mData[pEntity].iPlayerSuspicion++; Utils::ConLog("CheaterDetection", tfm::format("%s infracted for high avg packet choking {%.1f / %.1f}.", pInfo.name, mData[pEntity].pChoke.second, (14.f / server.flMultiplier)).c_str(), { 224, 255, 131, 255 }); mData[pEntity].pChoke = { 0, 0.f }; } }
-		if (mData[pEntity].flHitchance && server.flHighAccuracy) { if (mData[pEntity].flHitchance > (std::min(server.flHighAccuracy * 2, .95f)) && !mData[pEntity].pDetections.first && flScanningTime > 120.f) { mData[pEntity].iPlayerSuspicion += 5; Utils::ConLog("CheaterDetection", tfm::format("%s infracted for extremely high accuracy {%.1f / %.1f}.", pInfo.name, mData[pEntity].flHitchance, std::min(server.flHighAccuracy * 2, .95f)).c_str(), {224, 255, 131, 255}); } }
+		if (mData[pEntity].flHitchance && server.flHighAccuracy && mData[pEntity].mShots.first > 25) { if (mData[pEntity].flHitchance > (server.flHighAccuracy) && !mData[pEntity].pDetections.first && flScanningTime > 120.f) { mData[pEntity].iPlayerSuspicion += 5; Utils::ConLog("CheaterDetection", tfm::format("%s infracted for extremely high accuracy {%.1f / %.1f}.", pInfo.name, mData[pEntity].flHitchance, server.flHighAccuracy).c_str(), {224, 255, 131, 255}); } }
 		if (mData[pEntity].flScorePerSecond && server.flAverageScorePerSecond) { if (mData[pEntity].flScorePerSecond > (std::max(server.flAverageScorePerSecond, server.flFloorScore) * 3) && !mData[pEntity].pDetections.second && flScanningTime > 10.f) { mData[pEntity].iPlayerSuspicion += 5; Utils::ConLog("CheaterDetection", tfm::format("%s infracted for extremely high score per second {%.1f / %.1f}.", pInfo.name, mData[pEntity].flScorePerSecond, server.flAverageScorePerSecond).c_str(), {224, 255, 131, 255}); } }
 	
 		if (mData[pEntity].iPlayerSuspicion > INT_MAX_SUSPICION) { mData[pEntity].iPlayerSuspicion = 0; G::PlayerPriority[pInfo.friendsID].Mode = 4; }
@@ -179,7 +179,9 @@ void CCheaterDetection::FindHitchances(){	//	runs every 20 seconds
 	if (!flTotal || !iScanAmount) { return; }
 	const float flAvg = flTotal / iScanAmount;
 
-	Utils::ConLog("CheaterDetection[UTIL]", tfm::format("Calculated server hitchance data {%.1f}", flAvg).c_str(), {224, 255, 131, 255});
+	server.flHighAccuracy = std::min(server.flHighAccuracy * 2, .95f);
+
+	Utils::ConLog("CheaterDetection[UTIL]", tfm::format("Calculated server hitchance data {%.1f | %.1f}", flAvg, server.flHighAccuracy).c_str(), {224, 255, 131, 255});
 }
 
 void CCheaterDetection::Reset(){

--- a/Fedoraware/TeamFortress2/TeamFortress2/Features/AntiHack/CheaterDetection/CheaterDetection.cpp
+++ b/Fedoraware/TeamFortress2/TeamFortress2/Features/AntiHack/CheaterDetection/CheaterDetection.cpp
@@ -136,6 +136,7 @@ bool CCheaterDetection::IsDuckSpeed(CBaseEntity* pEntity){
 
 void CCheaterDetection::SimTime(CBaseEntity* pEntity){
 	if (Vars::Misc::CheaterDetection::Methods.Value & ~(1 << 2)) {
+		if (mData[pEntity].iNonDormantCleanQueries < 6) { return; }
 		const float flSimDelta = pEntity->GetSimulationTime() - pEntity->GetOldSimulationTime();
 		const int iTickDelta = TIME_TO_TICKS(flSimDelta);
 		if (mData[pEntity].pChoke.first = 0) { mData[pEntity].pChoke.second = iTickDelta; return; }

--- a/Fedoraware/TeamFortress2/TeamFortress2/Features/AntiHack/CheaterDetection/CheaterDetection.cpp
+++ b/Fedoraware/TeamFortress2/TeamFortress2/Features/AntiHack/CheaterDetection/CheaterDetection.cpp
@@ -1,226 +1,228 @@
 #include "CheaterDetection.h"
 
-// TODO: make these vars
-constexpr float FL_TICKCOUNT_MULTIPLIER = 0.1f;
-constexpr float FL_BHOP_MULTIPLIER = 0.5f;
-constexpr float FL_SNAP_MULTIPLIER = 0.1f;
-constexpr float FL_SUSPICION_REMOVAL = 0.2f;
-constexpr float FL_SUSPICION_GATE = 1.f;
+bool CCheaterDetection::ShouldScan(){
+	if (iLastScanTick == I::GlobalVars->tickcount) { return false; }
+	
+	if (flLastFrameTime) {
+		const float flRealFrameTime = I::GlobalVars->realtime - flLastFrameTime;
+		flLastFrameTime = I::GlobalVars->realtime;
+		const int iRealFPS = static_cast<int>(1.0f / flRealFrameTime);
 
-void conLogDetection(const char* text) {
-	if (Vars::Debug::DebugInfo.Value) {
-		static std::string clr({ '\x7', 'C', 'C', '0', '0', 'F', 'F' });
-		I::Cvar->ConsoleColorPrintf({ 204, 0, 255, 255 }, "[CheaterDetection] ");
-		I::Cvar->ConsoleColorPrintf({ 255, 255, 255, 255 }, text);
-		I::ClientModeShared->m_pChatElement->ChatPrintf(0, tfm::format("%s[CheaterDetection] \x1 %s", clr, text).c_str());
+		if (iRealFPS < server.iTickRate)
+		{ return false; }
 	}
-}
 
-bool CCheaterDetection::ShouldScan(int nIndex, int friendsID, CBaseEntity* pSuspect)
-{
-	if (g_EntityCache.IsFriend(nIndex) || G::IsIgnored(friendsID) || G::PlayerPriority[friendsID].Mode == 4) { return false; } // dont rescan this player if we know they are cheating, a friend, or ignored
-	if (pSuspect->GetDormant()) { return false; } // dont run this player if they are dormant
-	if (!pSuspect->IsAlive() || pSuspect->IsAGhost() || pSuspect->IsTaunting()) { return false; } // dont run this player if they are dead / ghost or taunting
+	if (const INetChannel* NetChannel = I::EngineClient->GetNetChannelInfo()) {
+		const float flLastReceive = NetChannel->GetTimeSinceLastReceived();
+		const float flMaxReceive = I::GlobalVars->interval_per_tick * 2;
+		const bool bIsTimeOut = NetChannel->IsTimingOut();
+		const bool bShouldSkip = (flLastReceive > flMaxReceive) || bIsTimeOut;
+		if (bShouldSkip) { return false; }
+	}
+
 	return true;
 }
 
-//bool CCheaterDetection::IsSteamNameDifferent(PlayerInfo_t pInfo)
-//{
-//	const CSteamID SteamID = CSteamID(static_cast<uint64>(pInfo.friendsID + 0x0110000100000000));
-//
-//	// this can be falsely triggered by a person being nicknamed without being our steam friend (pending friend) or changing their steam name since joining the game
-//	if (const char* steamName = g_SteamInterfaces.Friends015->GetFriendPersonaName(SteamID))
-//	{
-//		if (strcmp(pInfo.name, steamName) != 0)
-//		{
-//			for (int personaNum = 0; personaNum <= 5; personaNum++) {
-//				if (const char* historicalName = g_SteamInterfaces.Friends015->GetFriendPersonaNameHistory(SteamID, personaNum)) {
-//					if (strcmp(pInfo.name, historicalName) == 0) {
-//						return false;
-//					}
-//				}
-//				else {
-//					break;
-//				}
-//			}
-//			conLogDetection(tfm::format("%s was detected as name changing (%s => %s).\n", pInfo.name, pInfo.name, steamName).c_str());
-//			return true;
-//		}
-//	}
-//	return false;
-//}
+bool CCheaterDetection::ShouldScanEntity(CBaseEntity* pEntity){
+	const int iIndex = pEntity->GetIndex();
 
-bool CCheaterDetection::IsPitchInvalid(CBaseEntity* pSuspect)
-{
-	const Vec3 suspectAngles = pSuspect->GetEyeAngles();
-	if (!suspectAngles.IsZero())
-	{
-		if (suspectAngles.x >= 90.f || suspectAngles.x <= -90.f)
-		{
-			return true;
-		}
-		if (suspectAngles.z >= 51.f || suspectAngles.z <= -51.f)	//	used by roll exploit
-		{
-			return true;
-		}
+	// dont scan invalid players
+	if (pEntity->IsAlive() || pEntity->IsAGhost() || pEntity->IsTaunting()) { return false; }
+
+	// dont scan players that arent simulated this tick
+	if (pEntity->GetSimulationTime() == pEntity->GetOldSimulationTime()) { return false; }
+
+	// dont scan if we can't get playerinfo
+	PlayerInfo_t pInfo{};
+	if (!I::EngineClient->GetPlayerInfo(iIndex, &pInfo)) { return false; }
+	
+	// dont scan ignored players, friends, or players already marked as cheaters
+	switch (G::PlayerPriority[pInfo.friendsID].Mode){
+	case 0: case 1: case 4:
+	{ return false; }
+	}
+
+	return true;
+}
+
+bool CCheaterDetection::IsPitchLegal(CBaseEntity* pSuspect){
+	const Vec3 vAngles = pSuspect->GetEyeAngles();
+	return fabsf(vAngles.x) >= 90.f;
+}
+
+void CCheaterDetection::ReportTickCount(std::pair<CBaseEntity*, int> pReport){
+	if (mData[pReport.first].pChoke.first = 0) { mData[pReport.first].pChoke.second = pReport.second; return; }
+	mData[pReport.first].pChoke.first++;
+	mData[pReport.first].pChoke.second+= pReport.second;
+	return;
+}
+
+bool CCheaterDetection::CheckBHop(CBaseEntity* pEntity){
+	const bool bOnGround = pEntity->OnSolid();	//	NOTE: groundentity isn't networked properly sometimes i think
+	if (bOnGround) { mData[pEntity].pBhop.first++; }
+	else if (mData[pEntity].pBhop.first < 2) { mData[pEntity].pBhop.second++; mData[pEntity].pBhop.first = 0; }
+	else { mData[pEntity].pBhop = {0, 0}; }
+
+	if (mData[pEntity].pBhop.second > INT_MAX_BHOP) { mData[pEntity].iPlayerSuspicion++; mData[pEntity].pBhop = {0, 0}; return true; }
+	return false;
+}
+
+bool CCheaterDetection::AreAnglesSuspicious(CBaseEntity* pEntity){
+	// first check if we should scan this player at all
+	if (G::ChokeMap[pEntity->GetIndex()] > 0 || pEntity->GetVelocity().Length() < 10.f || mData[pEntity].vLastAngle.IsZero()) { mData[pEntity].pTrustAngles = {false, {0, 0}}; return false; } //	angles don't update the way I WANT them to if the player is not moving.
+	if (!mData[pEntity].pTrustAngles.first){	//	we are not suspicious of this player yet
+		const Vec3 vCurAngles = pEntity->GetEyeAngles();
+		const Vec2 vDelta = Vec2{vCurAngles.x, vCurAngles.y} - mData[pEntity].vLastAngle;
+		const float flDelta = vDelta.Length();
+
+		if (flDelta > (20.f)) { mData[pEntity].pTrustAngles = {true, {vCurAngles.x, vCurAngles.y}}; }
+	}
+	else {
+		//	check for noise on this player (how much their mouse moves after the initial flick)
+		const Vec3 vCurAngles = pEntity->GetEyeAngles();
+		const Vec2 vDelta = Vec2{vCurAngles.x, vCurAngles.y} - mData[pEntity].pTrustAngles.second;
+		const float flDelta = vDelta.Length();
+
+		if (flDelta < (5.f * server.flMultiplier)) { mData[pEntity].pTrustAngles = {false, {0, 0}}; return true; }
+		else { mData[pEntity].pTrustAngles = {false, {0, 0}}; }
 	}
 	return false;
 }
 
-void CCheaterDetection::ReportTickCount(CBaseEntity* pSuspect, const int iChange){
-	if (iChange < 15){return;}
-	PlayerInfo_t pi{ };
-	if (I::EngineClient->GetPlayerInfo(pSuspect->GetIndex(), &pi))
-	{
-		int friendsID = pi.friendsID;
-		PlayerData& userData = UserData[friendsID];
-		if (userData.NonDormantTimer < 67) {return;}
-		userData.PlayerSuspicion += Math::RemapValClamped((float)iChange, 0, 22, 0.f, 1.f) * FL_TICKCOUNT_MULTIPLIER;
-		conLogDetection(tfm::format("%s was detected as shifting their tickbase.\n", pi.name).c_str());
-	}
-}
-
-bool CCheaterDetection::TrustAngles(CBaseEntity* pSuspect, PlayerData& pData){
-	if (!pData.NonDormantTimer || G::ChokeMap[pSuspect->GetIndex()]) { return true; }	//	our old angle data will not be reliable
-	Vec3 oldAngles = pData.OldAngles; oldAngles.y = abs(oldAngles.y);
-	Vec3 curAngles = pSuspect->GetEyeAngles(); curAngles.y = abs(curAngles.y);
-
-	const Vec3 vDelta = oldAngles - curAngles;
-	const float flDelta = sqrt(pow(vDelta.x, 2) + pow(vDelta.y, 2));
-
-	if (flDelta > 35.f){	//	this was suspicious but we don't know if they are cheating yet
-		pData.StoredEndFlick = {true, curAngles};
-		return true;
-	}
-
-	if (!pData.StoredEndFlick.first){
-		return true;
-	}
-
-	//	we know they flicked and want to check for inaccuracy
-	const Vec3 vEndDelta = pData.StoredEndFlick.second - curAngles;
-	const float flEndDelta = sqrt(pow(vEndDelta.x, 2) + pow(vEndDelta.y, 2));;
-
-	if (flEndDelta < 0.1f){
-		pData.StoredEndFlick = {false, {0, 0, 0}};
-		return false;
-	}
-
-	pData.StoredEndFlick = {false, {0, 0, 0}};
-
-
-	return true;
-}
-
-bool CCheaterDetection::IsBhopping(CBaseEntity* pSuspect, PlayerData& pData)
-{
-	const bool onGround = pSuspect->m_fFlags() & FL_ONGROUND;
-	bool doReport = false;
-	if (onGround) {
-		pData.GroundTicks++;
-	}
-	else if (pData.GroundTicks) {
-		if (pData.GroundTicks <= 2) {
-			pData.BHopSuspicion++;
-		}
-		pData.GroundTicks = 0;
-	}
-
-	if (pData.BHopSuspicion >= 5) {
-		doReport = true;
-		pData.BHopSuspicion = 0;
-	}
-	else if (pData.GroundTicks > 2) {
-		pData.BHopSuspicion = 0;
-		pData.GroundTicks = 0;
-	}
-
-	return doReport;
+void CCheaterDetection::OnDormancy(CBaseEntity* pEntity){
+	mData[pEntity].pTrustAngles = {false, {0, 0}};
+	mData[pEntity].iNonDormantCleanQueries = 0;
+	mData[pEntity].vLastAngle = {};
+	mData[pEntity].pBhop = {false, 0};
+	mFired[pEntity] = false;
 }
 
 void CCheaterDetection::OnTick()
 {
 	const auto pLocal = g_EntityCache.GetLocal();
-	if (!pLocal || !I::EngineClient->IsConnected() || G::ShouldShift)
+	if (!pLocal || !I::EngineClient->IsConnected() || G::ShouldShift || !ShouldScan()) { return; }
+	iLastScanTick = I::GlobalVars->tickcount;
+	flScanningTime = I::GlobalVars->curtime - flFirstScanTime;
+	FindScores();
+	FindHitchances();
+
+	for (int n = 1; n < I::EngineClient->GetMaxClients(); n++)
 	{
-		return;
+		CBaseEntity* pEntity = I::ClientEntityList->GetClientEntity(n);
+		if (!pEntity) { continue; }
+		if (pEntity->GetDormant()) { OnDormancy(pEntity); continue; }
+		if (!ShouldScanEntity(pEntity)) { continue; }
+		if (pEntity == pLocal) { continue; }	//	i think for this code to run the local player has to be cheating anyway :thinking:
+		bool bMarked = false;	//	used for suspicion reduction
+
+		PlayerInfo_t pInfo{};
+		if (!I::EngineClient->GetPlayerInfo(pEntity->GetIndex(), &pInfo)) { continue; }
+
+		CalculateHitChance(pEntity);
+
+		if (!IsPitchLegal(pEntity)) { bMarked = true; mData[pEntity].iPlayerSuspicion = INT_MAX_SUSPICION; Utils::ConLog("CheaterDetection", tfm::format("%s marked for OOB angles.", pInfo.name).c_str(), {224, 255, 131, 255}); }
+		if (AreAnglesSuspicious(pEntity)) { bMarked = true; mData[pEntity].iPlayerSuspicion++; Utils::ConLog("CheaterDetection", tfm::format("%s infracted for suspicious angles.", pInfo.name).c_str(), {224, 255, 131, 255}); }
+		if (CheckBHop(pEntity)) { bMarked = true; Utils::ConLog("CheaterDetection", tfm::format("%s infracted for bunny-hopping.", pInfo.name).c_str(), {224, 255, 131, 255}); }
+
+		//analytical analysis
+		if ((mData[pEntity].pChoke.second / mData[pEntity].pChoke.first) > (14.f / server.flMultiplier) && mData[pEntity].pChoke.first > 10) { mData[pEntity].iPlayerSuspicion++; Utils::ConLog("CheaterDetection", tfm::format("%s infracted for high avg packet choking {%.1f / %.1f}.", pInfo.name, mData[pEntity].pChoke.second, (14.f / server.flMultiplier)).c_str(), { 224, 255, 131, 255 }); mData[pEntity].pChoke = { 0, 0.f }; }
+		if (mData[pEntity].flHitchance > (server.flQ2 + server.flQ3 * 1.6) && !mData[pEntity].pDetections.first && flScanningTime > 120.f) { mData[pEntity].iPlayerSuspicion += 5; Utils::ConLog("CheaterDetection", tfm::format("%s infracted for extremely high accuracy {%.1f / %.1f}.", pInfo.name, mData[pEntity].flHitchance, (server.flQ2 + server.flQ3 * 1.6)).c_str(), {224, 255, 131, 255}); }
+		if (mData[pEntity].flScorePerSecond > (server.flAverageScorePerSecond * 3) && !mData[pEntity].pDetections.second && flScanningTime > 10.f) { mData[pEntity].iPlayerSuspicion += 5; Utils::ConLog("CheaterDetection", tfm::format("%s infracted for extremely high score per second {%.1f / %.1f}.", pInfo.name, mData[pEntity].flScorePerSecond, server.flAverageScorePerSecond).c_str(), {224, 255, 131, 255}); }
+	}
+}
+
+void CCheaterDetection::FillServerInfo(){
+	server.flAverageScorePerSecond = 0.f;
+	server.mAccuracies.clear();
+	server.flQ1 = 0.f; server.flQ2 = 0.f; server.flQ3 = 0.f;
+	server.iTickRate = 1.f / I::GlobalVars->interval_per_tick;
+	server.flMultiplier = 66.7 / server.iTickRate;
+	Utils::ConLog("CheaterDetection[UTIL]", tfm::format("Calculated server tickrate & created appropriate multiplier {%.1f | %.1f}.", server.iTickRate, server.flMultiplier).c_str(), {224, 255, 131, 255});
+}
+
+void CCheaterDetection::FindScores(){	//	runs every 5 seconds
+	if (I::GlobalVars->curtime - flLastScoreTime < 5.f) { return; }
+	CTFPlayerResource* cResource = g_EntityCache.GetPR();
+	if (!cResource){ return; }
+	flLastScoreTime = I::GlobalVars->curtime;
+	
+	int iTotalScore = 0;
+	int iTotalPlayers = 0;
+	for (int n = 1; n < I::EngineClient->GetMaxClients(); n++)
+	{
+		CBaseEntity* pEntity = I::ClientEntityList->GetClientEntity(n);
+		if (!pEntity || !cResource->GetValid(pEntity->GetIndex())) { continue; }
+		const int iScore = cResource->GetScore(pEntity->GetIndex());
+		iTotalScore += iScore; iTotalPlayers++;	//	used for calculating the average score
 	}
 
-	{
-		// dont scan anybody if we are running at an fps lower than our updaterate (we dont check this against 66 for servers that run at a higher tickrate :D)
-		static float lastFrameTime = I::GlobalVars->realtime;
-		if (g_ConVars.cl_updaterate && lastFrameTime)
-		{
-			const float realFrameTime = I::GlobalVars->realtime - lastFrameTime;
-			lastFrameTime = I::GlobalVars->realtime;
-			const int realFPS = static_cast<int>(1.0f / realFrameTime);
+	if (!iTotalScore || !iTotalPlayers) { return; }
 
-			if (realFPS < g_ConVars.cl_updaterate->GetInt())
-			{
-				return;
-			}
-		}
+	// now that we've gone through all players (including local) find the avg
+	server.flAverageScorePerSecond = ((float)iTotalScore / (float)iTotalPlayers);
+	Utils::ConLog("CheaterDetection[UTIL]", tfm::format("Calculated avg. server score per second at %.1f.", server.flAverageScorePerSecond).c_str(), {224, 255, 131, 255});
+}
 
-		if (const INetChannel* NetChannel = I::EngineClient->GetNetChannelInfo()) {
-			const float lastReceivedUpdate = NetChannel->GetTimeSinceLastReceived();
-			const float maxReceiveTime = I::GlobalVars->interval_per_tick * 2;
-			const bool isTimingOut = NetChannel->IsTimingOut();
-			const bool shouldSkip = (lastReceivedUpdate > maxReceiveTime) || isTimingOut;
+void CCheaterDetection::FindHitchances(){	//	runs every 20 seconds
+	if (I::GlobalVars->curtime - flLastAccuracyTime < 20.f) { return; }
+	flLastAccuracyTime = I::GlobalVars->curtime;
 
-			if (shouldSkip) {
-				return;
-			}
-		}
+	std::vector<float> vUnsorted{};
+	std::map<CBaseEntity*, float>::iterator iter = server.mAccuracies.begin();
+	while (iter != server.mAccuracies.end()){
+		const float flAccuracy = iter->second;
+		vUnsorted.push_back(flAccuracy);
+		iter++;
 	}
 
-	for (const auto& pSuspect : g_EntityCache.GetGroup(EGroupType::PLAYERS_ALL))
-	{
-		if (!pSuspect) { continue; }
-		int index = pSuspect->GetIndex();
+	// we now have an unsorted vector, lets sort it
+	std::sort(vUnsorted.begin(), vUnsorted.end());
 
-		PlayerInfo_t pi{ };
-		if (I::EngineClient->GetPlayerInfo(index, &pi) && !pi.fakeplayer)
-		{
-			int friendsID = pi.friendsID;
+	// now that it's sorted, lets find the quartiles
+	const auto Q1 = vUnsorted.size() / 4;
+	const auto Q2 = vUnsorted.size() / 2;
+	const auto Q3 = Q1 + Q2;
 
-			PlayerData& userData = UserData[friendsID];
+	server.flQ1 = vUnsorted.at(vUnsorted.size()*(1/4));
+	server.flQ2 = vUnsorted.at(vUnsorted.size()*(2/4));
+	server.flQ3 = vUnsorted.at(vUnsorted.size()*(3/4));
 
-			if (index == pLocal->GetIndex() || !ShouldScan(index, friendsID, pSuspect)) { userData.NonDormantTimer = 0; continue; }
+	Utils::ConLog("CheaterDetection[UTIL]", tfm::format("Calculated med. server hitchance at %.1f.", server.flQ2).c_str(), {224, 255, 131, 255});
+}
 
-			if (IsPitchInvalid(pSuspect))
-			{
-				conLogDetection(tfm::format("%s was detected for sending an OOB pitch.\n", pi.name).c_str());
-				userData.PlayerSuspicion = 1.f; // because this cannot be falsely triggered, anyone detected by it should be marked as a cheater instantly 
-			}
+void CCheaterDetection::Reset(){
+	server = ServerData{};
+	mData.clear();
+	mFired.clear();
+	iLastScanTick = 0;
+	flLastFrameTime = 0.f;
+	flFirstScanTime = 0.f;
+	flScanningTime = 0.f;
+	flLastScoreTime = 0.f;
+	flLastAccuracyTime = 0.f;
+}
 
-			if (IsBhopping(pSuspect, userData)) {
-				conLogDetection(tfm::format("%s was detected as bhopping.\n", pi.name).c_str());
-				userData.PlayerSuspicion += 1.f * FL_BHOP_MULTIPLIER;
-			}
+void CCheaterDetection::OnLoad(){
+	Reset();
+	FillServerInfo();
+}
 
-			/*if (!TrustAngles(pSuspect, userData)){
-				conLogDetection(tfm::format("%s was detected as aim-snapping.\n", pi.name).c_str());
-				userData.PlayerSuspicion += 1.f * FL_SNAP_MULTIPLIER;
-			}*/
+void CCheaterDetection::CalculateHitChance(CBaseEntity* pEntity){
+	mData[pEntity].flHitchance = (float)mData[pEntity].mShots.first / (float)mData[pEntity].mShots.second;
+	server.mAccuracies[pEntity] = mData[pEntity].flHitchance;
+}
 
-			if (userData.PlayerSuspicion >= FL_SUSPICION_GATE)
-			{
-				conLogDetection(tfm::format("%s was marked as a cheater.\n", pi.name).c_str());
-				G::PlayerPriority[friendsID].Mode = 4; // Set priority to "Cheater"
-				userData.PlayerSuspicion = 0.f;	//	reset suspicion
-			}
-			else if (userData.OldPlayerSuspicion == userData.PlayerSuspicion && userData.PlayerSuspicion > 0.f) {
-				userData.PlayerSuspicion *= 0.95f;	//	lol
-				//conLogDetection(tfm::format("%s has had their suspicion reduced due to good behaviour.\n", pi.name).c_str());
-			}
+void CCheaterDetection::ReportShot(int iIndex){
+	CBaseEntity* pEntity = I::ClientEntityList->GetClientEntity(iIndex);
+	if (!pEntity){ return; }
+	mData[pEntity].mShots.second++;
+}
 
-			if (userData.OldPlayerSuspicion != userData.PlayerSuspicion) {
-				userData.NonDormantTimer = 0;
-			}
-
-			userData.OldAngles = pSuspect->GetEyeAngles();
-			userData.NonDormantTimer++;
-			userData.OldPlayerSuspicion = userData.PlayerSuspicion;
-		}
-	}
+void CCheaterDetection::ReportDamage(CGameEvent* pEvent){
+	const int iIndex = pEvent->GetInt("attacker");
+	CBaseEntity* pEntity = I::ClientEntityList->GetClientEntity(iIndex);
+	if (!pEntity){ return; }
+	if (I::GlobalVars->tickcount - mData[pEntity].iLastDamageEventTick <= 1){ return; }
+	mData[pEntity].iLastDamageEventTick = I::GlobalVars->tickcount;
+	mData[pEntity].mShots.first++;
 }

--- a/Fedoraware/TeamFortress2/TeamFortress2/Features/AntiHack/CheaterDetection/CheaterDetection.cpp
+++ b/Fedoraware/TeamFortress2/TeamFortress2/Features/AntiHack/CheaterDetection/CheaterDetection.cpp
@@ -77,7 +77,7 @@ bool CCheaterDetection::AreAnglesSuspicious(CBaseEntity* pEntity){
 
 		if (flDelta > (20.f)) { 
 			if (!mData[pEntity].bDidDamage) { mData[pEntity].pTrustAngles = {true, {vCurAngles.x, vCurAngles.y}}; }
-			else { return true; }	//	20 degree flick followed by damage, very suspicious.
+			else { return true; }	//	20 degree flick followed by damage, very suspicious. (this is bad redo it probably)
 		}
 	}
 	else {
@@ -90,6 +90,15 @@ bool CCheaterDetection::AreAnglesSuspicious(CBaseEntity* pEntity){
 		else { mData[pEntity].pTrustAngles = {false, {0, 0}}; }
 	}
 	return false;
+}
+
+void CCheaterDetection::SimTime(CBaseEntity* pEntity){
+	const float flSimDelta = pEntity->GetSimulationTime() - pEntity->GetOldSimulationTime();
+	const int iTickDelta = TIME_TO_TICKS(flSimDelta);
+	if (mData[pEntity].pChoke.first = 0) { mData[pEntity].pChoke.second = iTickDelta; return; }
+	mData[pEntity].pChoke.first++;
+	mData[pEntity].pChoke.second+= iTickDelta;
+	return;
 }
 
 void CCheaterDetection::OnDormancy(CBaseEntity* pEntity){
@@ -122,6 +131,7 @@ void CCheaterDetection::OnTick()
 		if (!I::EngineClient->GetPlayerInfo(pEntity->GetIndex(), &pInfo)) { continue; }
 
 		CalculateHitChance(pEntity);
+		SimTime(pEntity);
 
 		if (!IsPitchLegal(pEntity)) { bMarked = true; mData[pEntity].iPlayerSuspicion = INT_MAX_SUSPICION; Utils::ConLog("CheaterDetection", tfm::format("%s marked for OOB angles.", pInfo.name).c_str(), {224, 255, 131, 255}); }
 		if (AreAnglesSuspicious(pEntity)) { bMarked = true; mData[pEntity].iPlayerSuspicion++; Utils::ConLog("CheaterDetection", tfm::format("%s infracted for suspicious angles.", pInfo.name).c_str(), {224, 255, 131, 255}); }

--- a/Fedoraware/TeamFortress2/TeamFortress2/Features/AntiHack/CheaterDetection/CheaterDetection.cpp
+++ b/Fedoraware/TeamFortress2/TeamFortress2/Features/AntiHack/CheaterDetection/CheaterDetection.cpp
@@ -269,9 +269,9 @@ void CCheaterDetection::ReportDamage(CGameEvent* pEvent){
 	const int iIndex = pEvent->GetInt("attacker");
 	CBaseEntity* pEntity = I::ClientEntityList->GetClientEntity(iIndex);
 	if (!pEntity || pEntity->GetDormant()){ return; }
-	AimbotCheck(pEntity);
 	CBaseCombatWeapon* pWeapon = pEntity->GetActiveWeapon();
 	if (!pWeapon || Utils::GetWeaponType(pWeapon) != EWeaponType::HITSCAN) { return; }
+	AimbotCheck(pEntity);
 	if (I::GlobalVars->tickcount - mData[pEntity].iLastDamageEventTick <= 1){ return; }
 	mData[pEntity].iLastDamageEventTick = I::GlobalVars->tickcount;
 	mData[pEntity].pShots.first++; mData[pEntity].bDidDamage = true;

--- a/Fedoraware/TeamFortress2/TeamFortress2/Features/AntiHack/CheaterDetection/CheaterDetection.h
+++ b/Fedoraware/TeamFortress2/TeamFortress2/Features/AntiHack/CheaterDetection/CheaterDetection.h
@@ -9,6 +9,9 @@ struct PlayerData {
 	std::pair<bool, Vec2> pTrustAngles = {false, {0, 0}};
 	std::pair<bool, bool> pDetections = {false, false};	//	high hitchance, high avg score
 
+	//Immediate Data
+	bool bDidDamage = false;
+
 	//Tickbase Manipulation
 	std::pair<int, int> pChoke = {0, 0};
 
@@ -21,6 +24,8 @@ struct PlayerData {
 
 struct ServerData {
 	float flAverageScorePerSecond = 0.f;					//	used to determine if our player is in the top 99% or just average within the server
+	int iMisses = 0;										//	total shots fired
+	int iHits = 0;											//	total shots hit
 	float flHighAccuracy;									//	highest acceptable accuracy
 	int iTickRate = 0;										//	used for data
 	float flMultiplier = 1.f;								//	66.7 / iTickRate, real players should have shorter flicks on servers where the tickrate is higher, and larger flicks on lower tickrate servers

--- a/Fedoraware/TeamFortress2/TeamFortress2/Features/AntiHack/CheaterDetection/CheaterDetection.h
+++ b/Fedoraware/TeamFortress2/TeamFortress2/Features/AntiHack/CheaterDetection/CheaterDetection.h
@@ -17,10 +17,11 @@ struct PlayerData {
 	std::pair<int, int> pChoke = {0, 0};
 
 	//Analytics
-	std::pair<int, int> mShots = {0, 0};
+	std::pair<int, float> pDuckInfo = {0, 0};
+	std::pair<int, int> pShots = {0, 0};
 	float flHitchance = 0.f;
 	float flScorePerSecond = 0.f;
-	int iLastDamageEventTick = 0; // lets not recalculate hitchance for a player multiple times (explosive dmg, weird shell weapon behaviour)
+	int iLastDamageEventTick = 0;	// lets not recalculate hitchance for a player multiple times (explosive dmg, weird shell weapon behaviour)
 };
 
 struct ServerData {
@@ -60,6 +61,8 @@ class CCheaterDetection {
 	bool CheckBHop(CBaseEntity* pEntity);
 	bool AreAnglesSuspicious(CBaseEntity* pEntity);
 	void SimTime(CBaseEntity* pEntity);
+	void AimbotCheck(CBaseEntity* pEntity);
+	bool IsDuckSpeed(CBaseEntity* pEntity);
 
 	// player utils
 	void CalculateHitChance(CBaseEntity* pEntity);

--- a/Fedoraware/TeamFortress2/TeamFortress2/Features/AntiHack/CheaterDetection/CheaterDetection.h
+++ b/Fedoraware/TeamFortress2/TeamFortress2/Features/AntiHack/CheaterDetection/CheaterDetection.h
@@ -21,8 +21,7 @@ struct PlayerData {
 
 struct ServerData {
 	float flAverageScorePerSecond = 0.f;					//	used to determine if our player is in the top 99% or just average within the server
-	std::map<CBaseEntity*, float> mAccuracies{};			//	stores the accuracy for all players
-	float flQ1, flQ2, flQ3;									//	quartiles
+	float flHighAccuracy;									//	highest acceptable accuracy
 	int iTickRate = 0;										//	used for data
 	float flMultiplier = 1.f;								//	66.7 / iTickRate, real players should have shorter flicks on servers where the tickrate is higher, and larger flicks on lower tickrate servers
 	float flFloorScore = 0.05f;								//	assume this as the minimum average score, what if a majority of the server is friendly, instead of a minimum score to be included, just set this as the average

--- a/Fedoraware/TeamFortress2/TeamFortress2/Features/AntiHack/CheaterDetection/CheaterDetection.h
+++ b/Fedoraware/TeamFortress2/TeamFortress2/Features/AntiHack/CheaterDetection/CheaterDetection.h
@@ -56,7 +56,7 @@ class CCheaterDetection {
 	bool AreAnglesSuspicious(CBaseEntity* pEntity);
 	void OnDormancy(CBaseEntity* pEntity);
 
-	// player mafmatics
+	// player utils
 	void CalculateHitChance(CBaseEntity* pEntity);
 
 	// server functions

--- a/Fedoraware/TeamFortress2/TeamFortress2/Features/AntiHack/CheaterDetection/CheaterDetection.h
+++ b/Fedoraware/TeamFortress2/TeamFortress2/Features/AntiHack/CheaterDetection/CheaterDetection.h
@@ -2,6 +2,7 @@
 #include "../../../SDK/SDK.h"
 struct PlayerData {
 	//Data
+	float flJoinTime = 0.f;
 	Vec2 vLastAngle = {0, 0};
 	int iPlayerSuspicion = 0;
 	int iNonDormantCleanQueries = 0;

--- a/Fedoraware/TeamFortress2/TeamFortress2/Features/AntiHack/CheaterDetection/CheaterDetection.h
+++ b/Fedoraware/TeamFortress2/TeamFortress2/Features/AntiHack/CheaterDetection/CheaterDetection.h
@@ -58,10 +58,11 @@ class CCheaterDetection {
 	bool IsPitchLegal(CBaseEntity* pEntity);
 	bool CheckBHop(CBaseEntity* pEntity);
 	bool AreAnglesSuspicious(CBaseEntity* pEntity);
-	void OnDormancy(CBaseEntity* pEntity);
+	void SimTime(CBaseEntity* pEntity);
 
 	// player utils
 	void CalculateHitChance(CBaseEntity* pEntity);
+	void OnDormancy(CBaseEntity* pEntity);
 
 	// server functions
 	void FindScores();

--- a/Fedoraware/TeamFortress2/TeamFortress2/Features/AntiHack/CheaterDetection/CheaterDetection.h
+++ b/Fedoraware/TeamFortress2/TeamFortress2/Features/AntiHack/CheaterDetection/CheaterDetection.h
@@ -1,26 +1,77 @@
 #pragma once
 #include "../../../SDK/SDK.h"
-
 struct PlayerData {
-	float PlayerSuspicion = 0.f;
-	float OldPlayerSuspicion = 0.f;
-	int GroundTicks = 0;				//	counts how many ticks our target has been on the ground
-	int BHopSuspicion = 0;				//	maxes out at 5, resets, adds a strike
-	int NonDormantTimer = 0;			//	stores how many ticks we have properly scanned this player for without striking them
-	Vec3 OldAngles{0, 0, 0};			//	stores the eye angles from the last tick on this player
-	std::pair<bool, Vec3> StoredEndFlick{false, {0, 0, 0}};
+	//Data
+	Vec2 vLastAngle = {0, 0};
+	int iPlayerSuspicion = 0;
+	int iNonDormantCleanQueries = 0;
+	std::pair<int, int> pBhop = {0, 0};
+	std::pair<bool, Vec2> pTrustAngles = {false, {0, 0}};
+	std::pair<bool, bool> pDetections = {false, false};	//	high hitchance, high avg score
+
+	//Tickbase Manipulation
+	std::pair<int, int> pChoke = {0, 0};
+
+	//Analytics
+	std::pair<int, int> mShots = {0, 0};
+	float flHitchance = 0.f;
+	float flScorePerSecond = 0.f;
+	int iLastDamageEventTick = 0; // lets not recalculate hitchance for a player multiple times (explosive dmg, weird shell weapon behaviour)
 };
 
-class CCheaterDetection {
-	std::unordered_map<int, PlayerData> UserData;
-	bool ShouldScan(int nIndex, int friendsID, CBaseEntity* pSuspect);
-	bool IsPitchInvalid(CBaseEntity* pSuspect);
-	bool IsBhopping(CBaseEntity* pSuspect, PlayerData& pData);
-	bool TrustAngles(CBaseEntity* pSuspect, PlayerData& pData);
+struct ServerData {
+	float flAverageScorePerSecond = 0.f;					//	used to determine if our player is in the top 99% or just average within the server
+	std::map<CBaseEntity*, float> mAccuracies{};			//	stores the accuracy for all players
+	float flQ1, flQ2, flQ3;									//	quartiles
+	int iTickRate = 0;										//	used for data
+	float flMultiplier = 1.f;								//	66.7 / iTickRate, real players should have shorter flicks on servers where the tickrate is higher, and larger flicks on lower tickrate servers
+	float flFloorScore = 0.05f;								//	assume this as the minimum average score, what if a majority of the server is friendly, instead of a minimum score to be included, just set this as the average
+};
 
+// TODO: make these vars
+constexpr int INT_MAX_SUSPICION = 25;
+constexpr int INT_MAX_BHOP = 5;
+
+class CCheaterDetection {
+	// data
+	int iLastScanTick = 0;
+	float flLastFrameTime = 0.f;
+	float flFirstScanTime = 0.f;
+	float flScanningTime = 0.f;
+	float flLastScoreTime = 0.f;
+	float flLastAccuracyTime = 0.f;
+	ServerData server;
+	std::unordered_map<CBaseEntity*, PlayerData> mData;
+	std::unordered_map<CBaseEntity*, bool> mFired;
+
+	// is it safe for the client to be doing this, is the process drunk & unable to make proper judgement, has it been bribed???/?
+	bool ShouldScan();
+
+	// is the player fit for scanning on this tick
+	bool ShouldScanEntity(CBaseEntity* pEntity);
+
+	// player checks
+	bool IsPitchLegal(CBaseEntity* pEntity);
+	bool CheckBHop(CBaseEntity* pEntity);
+	bool AreAnglesSuspicious(CBaseEntity* pEntity);
+	void OnDormancy(CBaseEntity* pEntity);
+
+	// player mafmatics
+	void CalculateHitChance(CBaseEntity* pEntity);
+
+	// server functions
+	void FindScores();
+	void FindHitchances();
+	void FillServerInfo();
+
+	//
+	void Reset();
 public:
 	void OnTick();
-	void ReportTickCount(CBaseEntity* pSuspect, const int iChange);
+	void ReportTickCount(std::pair<CBaseEntity*, int> pReport);
+	void ReportShot(int iIndex);
+	void ReportDamage(CGameEvent* pEvent);
+	void OnLoad();
 };
 
 ADD_FEATURE(CCheaterDetection, BadActors)

--- a/Fedoraware/TeamFortress2/TeamFortress2/Features/AntiHack/FakeLag/FakeLag.cpp
+++ b/Fedoraware/TeamFortress2/TeamFortress2/Features/AntiHack/FakeLag/FakeLag.cpp
@@ -30,11 +30,13 @@ bool CFakeLag::DuckLogic(CBaseEntity* pLocal) {	//	0, do nothing, 1 choke, 2
 }
 
 bool CFakeLag::IsAllowed(CBaseEntity* pLocal) {
+	INetChannel* iNetChan = I::EngineClient->GetNetChannelInfo();
 	const int doubleTapAllowed = 22 - G::ShiftedTicks;
 	const bool retainFakelagTest = Vars::Misc::CL_Move::RetainFakelag.Value ? G::ShiftedTicks != 1 : !G::ShiftedTicks;
+	if (!iNetChan) { return false; }	//	no netchannel no fakelag
 
 	// Failsafe, in case we're trying to choke too many ticks
-	if (ChokeCounter > 21) 
+	if (std::max(ChokeCounter, iNetChan->m_nChokedPackets) > 21) 
 	{ return false; }
 
 	// Are we attacking? TODO: Add more logic here

--- a/Fedoraware/TeamFortress2/TeamFortress2/Features/AntiHack/FakeLag/FakeLag.cpp
+++ b/Fedoraware/TeamFortress2/TeamFortress2/Features/AntiHack/FakeLag/FakeLag.cpp
@@ -44,10 +44,10 @@ bool CFakeLag::IsAllowed(CBaseEntity* pLocal) {
 	{ return false; }
 
 	// Are we recharging
-	if (ChokeCounter >= doubleTapAllowed || G::Recharging || G::RechargeQueued || !retainFakelagTest) 
+	if ((ChokeCounter >= doubleTapAllowed || G::Recharging || G::RechargeQueued || !retainFakelagTest) && Vars::Misc::CL_Move::Enabled.Value)
 	{ return false; }
 
-	if (DuckLogic(pLocal))
+	if (DuckLogic(pLocal) || (Vars::Misc::CL_Move::WhileInAir.Value && !pLocal->OnSolid()))
 	{ return true; }	//	no other checks, we want this
 
 	// Is a fakelag key set and pressed?

--- a/Fedoraware/TeamFortress2/TeamFortress2/Features/AntiHack/FakeLag/FakeLag.h
+++ b/Fedoraware/TeamFortress2/TeamFortress2/Features/AntiHack/FakeLag/FakeLag.h
@@ -13,9 +13,10 @@ class CFakeLag {
 	Vec3 vLastPosition;
 
 	bool IsVisible(CBaseEntity* pLocal);
+	bool IsAllowed(CBaseEntity* pLocal);
+	bool DuckLogic(CBaseEntity* pLocal);
 
 public:
-	bool IsAllowed(CBaseEntity* pLocal);
 	void OnTick(CUserCmd* pCmd, bool* pSendPacket);
 };
 

--- a/Fedoraware/TeamFortress2/TeamFortress2/Features/Auto/AutoStab/AutoStab.cpp
+++ b/Fedoraware/TeamFortress2/TeamFortress2/Features/Auto/AutoStab/AutoStab.cpp
@@ -123,94 +123,83 @@ void CAutoStab::RunRage(CBaseEntity* pLocal, CBaseCombatWeapon* pWeapon, CUserCm
 		Vec3 vOriginalPos = pEnemy->GetAbsOrigin();
 		Vec3 vOriginalEyeAngles = pEnemy->GetEyeAngles();
 
-		//if (bBacktrackable)
-		//{
-		//	auto DoBacktrack = [&](TickRecord pTick) -> bool {
-		//		pEnemy->SetAbsOrigin(vOriginalPos);
-		//		pEnemy->SetEyeAngles(vOriginalEyeAngles);
-		//
-		//		// Check if the tick is in range
-		//		if (!F::Backtrack.IsTickInRange(pTick.TickCount))
-		//		{
-		//			return false;
-		//		}
-		//
-		//		// Extract the required bones
-		//		const auto pBoneMatrix = (matrix3x4*)&pTick.BoneMatrix;
-		//		const Vec3 vPelvisPos = Vec3(pBoneMatrix[HITBOX_PELVIS][0][3],
-		//		                             pBoneMatrix[HITBOX_PELVIS][1][3],
-		//		                             pBoneMatrix[HITBOX_PELVIS][2][3]);
-		//
-		//		vAngleTo = Math::CalcAngle(pLocal->GetShootPos(), vPelvisPos);
-		//
-		//		// Set origins and eye angles for further logic
-		//		pEnemy->SetAbsOrigin(pTick.AbsOrigin);
-		//		pEnemy->SetEyeAngles(pTick.EyeAngles);
-		//
-		//		// Check stab range (option)
-		//		const float flRange = (48.0f * Vars::Triggerbot::Stab::Range.Value);
-		//		if (flRange <= 0.0f) { return false; }
-		//
-		//		if (pTick.WorldSpaceCenter.DistTo(pLocal->GetWorldSpaceCenter()) > flRange * 2)
-		//		{
-		//			pEnemy->SetAbsOrigin(vOriginalPos);
-		//			pEnemy->SetEyeAngles(vOriginalEyeAngles);
-		//			return false;
-		//		}
-		//
-		//		// Can we backstab the target?
-		//		if (!CanBackstab(vAngleTo, pEnemy->GetEyeAngles(), (pTick.WorldSpaceCenter - pLocal->GetWorldSpaceCenter())))
-		//		{
-		//			pEnemy->SetAbsOrigin(vOriginalPos);
-		//			pEnemy->SetEyeAngles(vOriginalEyeAngles);
-		//			return false;
-		//		}
-		//
-		//		// Silent backstab
-		//		if (Vars::Triggerbot::Stab::Silent.Value)
-		//		{
-		//			Utils::FixMovement(pCmd, vAngleTo);
-		//			G::SilentTime = true;
-		//		}
-		//
-		//		pCmd->viewangles = vAngleTo;
-		//		pCmd->buttons |= IN_ATTACK;
-		//		m_bShouldDisguise = true;
-		//
-		//		if (Vars::Misc::DisableInterpolation.Value)
-		//		{
-		//			pCmd->tick_count = TIME_TO_TICKS(pTick.SimulationTime + G::LerpTime);
-		//		}
-		//		else
-		//		{
-		//			pCmd->tick_count = TIME_TO_TICKS(pTick.SimulationTime);
-		//		}
-		//
-		//		pEnemy->SetAbsOrigin(vOriginalPos);
-		//		pEnemy->SetEyeAngles(vOriginalEyeAngles);
-		//
-		//		return true;
-		//	};
-		//
-		//	/* Backstrack stab */
-		//	if (Vars::Backtrack::LastTick.Value)
-		//	{
-		//		// Last Tick
-		//		const auto& lastTick = F::Backtrack.GetRecord(pEnemy->GetIndex(), BacktrackMode::Last);
-		//		if (lastTick && DoBacktrack(*lastTick))
-		//		{
-		//			return;
-		//		}
-		//	}
-		//	else
-		//	{
-		//		// Any Tick
-		//		for (const auto& pTick : *pRecords)
-		//		{
-		//			if (DoBacktrack(pTick)) { return; }
-		//		}
-		//	}
-		//}
+		if (bBacktrackable)
+		{
+			auto DoBacktrack = [&](TickRecordNew pTick) -> bool {
+				pEnemy->SetAbsOrigin(vOriginalPos);
+				pEnemy->SetEyeAngles(vOriginalEyeAngles);
+		
+				// Extract the required bones
+				const auto pBoneMatrix = (matrix3x4*)&pTick.BoneMatrix;
+				const Vec3 vPelvisPos = Vec3(pBoneMatrix[HITBOX_PELVIS][0][3],
+				                             pBoneMatrix[HITBOX_PELVIS][1][3],
+				                             pBoneMatrix[HITBOX_PELVIS][2][3]);
+		
+				vAngleTo = Math::CalcAngle(pLocal->GetShootPos(), vPelvisPos);
+		
+				// Set origins and eye angles for further logic
+				pEnemy->SetAbsOrigin(pTick.vOrigin);
+				pEnemy->SetEyeAngles(pTick.vAngles);
+		
+				// Check stab range (option)
+				const float flRange = (48.0f * Vars::Triggerbot::Stab::Range.Value);
+				if (flRange <= 0.0f) { return false; }
+		
+				if (pTick.vOrigin.DistTo(pLocal->m_vecOrigin()) > flRange)
+				{
+					pEnemy->SetAbsOrigin(vOriginalPos);
+					pEnemy->SetEyeAngles(vOriginalEyeAngles);
+					return false;
+				}
+		
+				// Can we backstab the target?
+				if (!CanBackstab(vAngleTo, pEnemy->GetEyeAngles(), (pTick.vOrigin - pLocal->m_vecOrigin())))
+				{
+					pEnemy->SetAbsOrigin(vOriginalPos);
+					pEnemy->SetEyeAngles(vOriginalEyeAngles);
+					return false;
+				}
+		
+				// Silent backstab
+				if (Vars::Triggerbot::Stab::Silent.Value)
+				{
+					Utils::FixMovement(pCmd, vAngleTo);
+					G::SilentTime = true;
+				}
+		
+				pCmd->viewangles = vAngleTo;
+				pCmd->buttons |= IN_ATTACK;
+				m_bShouldDisguise = true;
+
+				pCmd->tick_count = TIME_TO_TICKS(pTick.flSimTime + G::LerpTime);
+		
+				pEnemy->SetAbsOrigin(vOriginalPos);
+				pEnemy->SetEyeAngles(vOriginalEyeAngles);
+		
+				return true;
+			};
+		
+			/* Backstrack stab */
+			if (Vars::Backtrack::LastTick.Value)
+			{
+				// Last Tick
+				std::optional<TickRecordNew> vLastRec = F::BacktrackNew.GetLastRecord(pEnemy);
+				if (vLastRec && DoBacktrack(*vLastRec))
+				{
+					return;
+				}
+			}
+			else
+			{
+				// Any Tick
+				for (const auto& pTick : *pRecords)
+				{
+					if (!F::BacktrackNew.WithinRewind(pTick)) { continue; }
+					if (DoBacktrack(pTick)) { return; }
+				}
+			}
+		}
+		else
 		{
 			/* Default stab */
 			if (!TraceMelee(pLocal, pWeapon, vAngleTo, &pTraceEnemy) || pTraceEnemy != pEnemy)

--- a/Fedoraware/TeamFortress2/TeamFortress2/Features/Auto/AutoStab/AutoStab.cpp
+++ b/Fedoraware/TeamFortress2/TeamFortress2/Features/Auto/AutoStab/AutoStab.cpp
@@ -117,7 +117,7 @@ void CAutoStab::RunRage(CBaseEntity* pLocal, CBaseCombatWeapon* pWeapon, CUserCm
 
 		Vec3 vAngleTo = Math::CalcAngle(pLocal->GetShootPos(), pEnemy->GetHitboxPos(HITBOX_PELVIS));
 
-		const auto& pRecords = F::Backtrack.GetPlayerRecords(pEnemy->GetIndex());
+		const auto& pRecords = F::BacktrackNew.GetRecords(pEnemy);
 		const bool bBacktrackable = pRecords != nullptr && Vars::Backtrack::Enabled.Value;
 
 		Vec3 vOriginalPos = pEnemy->GetAbsOrigin();

--- a/Fedoraware/TeamFortress2/TeamFortress2/Features/Backtrack/Backtrack.cpp
+++ b/Fedoraware/TeamFortress2/TeamFortress2/Features/Backtrack/Backtrack.cpp
@@ -10,9 +10,9 @@ bool CBacktrackNew::WithinRewind(TickRecordNew Record){	//	check if we can go to
 	
 	if (!pLocal || !iNetChan) { return false; }
 
-	const float flTickArriveTime = GetLatency() - iNetChan->GetLatency(FLOW_INCOMING) - iNetChan->GetLatency(FLOW_OUTGOING);
-	const float flRawDelta = TICKS_TO_TIME(abs(Record.iTickCount - G::LastUserCmd->tick_count + 1));
-	const float flDelta = fabsf(flRawDelta + flTickArriveTime);
+	const float flTickArriveTime = GetLatency() + iNetChan->GetLatency(FLOW_INCOMING);
+	const float flRawDelta = (I::GlobalVars->curtime - Record.flSimTime);
+	const float flDelta = fabsf(flTickArriveTime - flRawDelta);
 
 	return flDelta < .2f;	//	in short, check if the record is +- 200ms from us
 }
@@ -94,8 +94,8 @@ float CBacktrackNew::GetLatency()
 {
 	if (INetChannel* iNetChan = I::EngineClient->GetNetChannelInfo()){
 		const float flRealLatency = iNetChan->GetLatency(FLOW_OUTGOING) + G::LerpTime;
-		const float flFakeLatency = flLatencyRampup * (float)std::clamp(Vars::Backtrack::Latency.Value, 0, 800) / 1000.f;
-		const float flAdjustedLatency = std::clamp((flRealLatency + (bFakeLatency ? flFakeLatency : 0.f)), 0.f, 1.f);
+		const float flFakeLatency = (float)std::clamp(Vars::Backtrack::Latency.Value, 0, 800) / 1000.f;
+		const float flAdjustedLatency = flLatencyRampup * std::clamp((flRealLatency + (bFakeLatency ? flFakeLatency : 0.f)), 0.f, 1.f);
 		return flAdjustedLatency;
 	}
 

--- a/Fedoraware/TeamFortress2/TeamFortress2/Features/Backtrack/Backtrack.cpp
+++ b/Fedoraware/TeamFortress2/TeamFortress2/Features/Backtrack/Backtrack.cpp
@@ -133,7 +133,6 @@ void CBacktrackNew::FrameStageNotify(){
 	if (!pLocal || !iNetChan) { return Restart(); }
 
 	flLatencyRampup = std::min(1.f, flLatencyRampup += I::GlobalVars->interval_per_tick);
-	UpdateDatagram();
 	MakeRecords();
 	CleanRecords();
 }
@@ -164,7 +163,9 @@ std::optional<TickRecordNew> CBacktrackNew::GetHitRecord(CUserCmd* pCmd, CBaseEn
 }
 
 std::optional<TickRecordNew> CBacktrackNew::Run(CUserCmd* pCmd){
-	if (G::IsAttacking && Vars::Backtrack::Enabled.Value){
+	if (!Vars::Backtrack::Enabled.Value) { return std::nullopt; }
+	UpdateDatagram();
+	if (G::IsAttacking){
 		CBaseEntity* pLocal = g_EntityCache.GetLocal();
 		if (!pLocal) { return std::nullopt; }
 		

--- a/Fedoraware/TeamFortress2/TeamFortress2/Features/Backtrack/Backtrack.cpp
+++ b/Fedoraware/TeamFortress2/TeamFortress2/Features/Backtrack/Backtrack.cpp
@@ -10,8 +10,8 @@ bool CBacktrackNew::WithinRewind(TickRecordNew Record){	//	check if we can go to
 	
 	if (!pLocal || !iNetChan) { return false; }
 
-	const float flDelay = std::clamp(GetLatency(), 0.f, 1.f);	//	TODO:: sv_maxunlag
-	const float flDelta = flDelay - TICKS_TO_TIME(I::GlobalVars->tickcount - Record.iTickCount);
+	const float flDelay = std::clamp(iNetChan->GetLatency(FLOW_OUTGOING) + GetLatency(), 0.f, 1.f);	//	TODO:: sv_maxunlag
+	const float flDelta = flDelay - (I::GlobalVars->curtime - Record.flSimTime);
 
 	return fabsf(flDelta) < .2f;	//	in short, check if the record is +- 200ms from us
 }

--- a/Fedoraware/TeamFortress2/TeamFortress2/Features/Backtrack/Backtrack.cpp
+++ b/Fedoraware/TeamFortress2/TeamFortress2/Features/Backtrack/Backtrack.cpp
@@ -10,7 +10,7 @@ bool CBacktrackNew::WithinRewind(TickRecordNew Record){	//	check if we can go to
 	
 	if (!pLocal || !iNetChan) { return false; }
 
-	const float flDelay = std::clamp(iNetChan->GetLatency(FLOW_OUTGOING) + GetLatency(), 0.f, 1.f);	//	TODO:: sv_maxunlag
+	const float flDelay = std::clamp(GetLatency() - iNetChan->GetLatency(FLOW_OUTGOING) - iNetChan->GetLatency(FLOW_INCOMING), 0.f, 1.f);	//	TODO:: sv_maxunlag
 	const float flDelta = flDelay - (I::GlobalVars->curtime - Record.flSimTime);
 
 	return fabsf(flDelta) < .2f;	//	in short, check if the record is +- 200ms from us

--- a/Fedoraware/TeamFortress2/TeamFortress2/Features/Backtrack/Backtrack.cpp
+++ b/Fedoraware/TeamFortress2/TeamFortress2/Features/Backtrack/Backtrack.cpp
@@ -11,7 +11,7 @@ bool CBacktrackNew::WithinRewind(TickRecordNew Record){	//	check if we can go to
 	if (!pLocal || !iNetChan) { return false; }
 
 	const float flDelay = std::clamp(GetLatency(), 0.f, 1.f);	//	TODO:: sv_maxunlag
-	const float flDelta = flDelay - (TICKS_TO_TIME(pLocal->m_nTickBase()) - Record.flSimTime);
+	const float flDelta = flDelay - TICKS_TO_TIME(I::GlobalVars->tickcount - Record.iTickCount);
 
 	return fabsf(flDelta) < .2f;	//	in short, check if the record is +- 200ms from us
 }
@@ -131,7 +131,7 @@ void CBacktrackNew::ReportShot(int iIndex){
 	if (!pEntity) { return; }
 	CBaseCombatWeapon* pWeapon = pEntity->GetActiveWeapon();
 	if (!pWeapon) { return; }
-	mDidShoot[iIndex] = Utils::GetWeaponType(pWeapon) == EWeaponType::HITSCAN;
+	mDidShoot[pEntity->GetIndex()] = Utils::GetWeaponType(pWeapon) == EWeaponType::HITSCAN;
 }
 
 std::optional<TickRecordNew> CBacktrackNew::GetHitRecord(CUserCmd* pCmd, CBaseEntity* pEntity, const Vec3 vAngles, const Vec3 vPos){

--- a/Fedoraware/TeamFortress2/TeamFortress2/Features/Backtrack/Backtrack.cpp
+++ b/Fedoraware/TeamFortress2/TeamFortress2/Features/Backtrack/Backtrack.cpp
@@ -21,9 +21,9 @@ bool CBacktrackNew::WithinRewind(TickRecordNew Record){	//	check if we can go to
 	if (!pLocal || !iNetChan) { return false; }
 
 	const float flDelay = std::clamp(GetLatency(), 0.f, 1.f);	//	TODO:: sv_maxunlag
-	const float flDelta = flDelay - TICKS_TO_TIME(pLocal->m_nTickBase() - Record.iTickCount);
+	const float flDelta = flDelay - (TICKS_TO_TIME(pLocal->m_nTickBase()) - Record.flSimTime);
 
-	return fabsf(flDelta) < .2f;	//	in short, check if the record is +- 200ms from us
+	return flDelta > -(.2f - I::GlobalVars->interval_per_tick) && flDelta < .2f;	//	in short, check if the record is +- 200ms from us
 }
 
 void CBacktrackNew::CleanRecords(){

--- a/Fedoraware/TeamFortress2/TeamFortress2/Features/Backtrack/Backtrack.cpp
+++ b/Fedoraware/TeamFortress2/TeamFortress2/Features/Backtrack/Backtrack.cpp
@@ -10,8 +10,8 @@ bool CBacktrackNew::WithinRewind(TickRecordNew Record){	//	check if we can go to
 	
 	if (!pLocal || !iNetChan) { return false; }
 
-	const float flDelay = std::clamp(GetLatency() - iNetChan->GetLatency(FLOW_OUTGOING) - iNetChan->GetLatency(FLOW_INCOMING), 0.f, 1.f);	//	TODO:: sv_maxunlag
-	const float flDelta = flDelay - (I::GlobalVars->curtime - Record.flSimTime);
+	const float flDelay = std::clamp(GetLatency() + iNetChan->GetLatency(FLOW_INCOMING), 0.f, 1.f);	//	TODO:: sv_maxunlag
+	const float flDelta = flDelay - (TICKS_TO_TIME(pLocal->m_nTickBase()) -TICKS_TO_TIME(Record.iTickCount));
 
 	return fabsf(flDelta) < .2f;	//	in short, check if the record is +- 200ms from us
 }
@@ -257,6 +257,7 @@ std::optional<TickRecordNew> CBacktrackNew::GetFirstRecord(CBaseEntity* pEntity)
 		if (!IsTracked(rCurQuery) || !WithinRewind(rCurQuery)) { continue; }
 		return rCurQuery;
 	}
+	return std::nullopt;
 }
 
 // Adjusts the fake latency ping

--- a/Fedoraware/TeamFortress2/TeamFortress2/Features/Backtrack/Backtrack.cpp
+++ b/Fedoraware/TeamFortress2/TeamFortress2/Features/Backtrack/Backtrack.cpp
@@ -102,10 +102,10 @@ float CBacktrackNew::GetLatency()
 }
 
 void CBacktrackNew::PlayerHurt(CGameEvent* pEvent){
-	const int iIndex = I::EngineClient->GetPlayerForUserID(pEvent->GetInt("userid"));
-	if (CBaseEntity* pEntity = I::ClientEntityList->GetClientEntity(iIndex)){
-		mRecords[pEntity].clear();	//	bone cache has gone to poop for this entity, they must be cleansed in holy fire :smiling_imp:
-	}
+	//const int iIndex = I::EngineClient->GetPlayerForUserID(pEvent->GetInt("userid"));
+	//if (CBaseEntity* pEntity = I::ClientEntityList->GetClientEntity(iIndex)){
+	//	mRecords[pEntity].clear();	//	bone cache has gone to poop for this entity, they must be cleansed in holy fire :smiling_imp:
+	//}
 }
 
 void CBacktrackNew::Restart(){

--- a/Fedoraware/TeamFortress2/TeamFortress2/Features/Backtrack/Backtrack.cpp
+++ b/Fedoraware/TeamFortress2/TeamFortress2/Features/Backtrack/Backtrack.cpp
@@ -102,7 +102,7 @@ void CBacktrackNew::UpdateDatagram()
 float CBacktrackNew::GetLatency()
 {
 	if (INetChannel* iNetChan = I::EngineClient->GetNetChannelInfo()){
-		const float flRealLatency = iNetChan->GetLatency(FLOW_INCOMING) + iNetChan->GetLatency(FLOW_OUTGOING) + G::LerpTime;
+		const float flRealLatency = iNetChan->GetLatency(FLOW_OUTGOING) + G::LerpTime;
 		const float flFakeLatency = (float)std::clamp(Vars::Backtrack::Latency.Value, 0, 800) / 1000.f;
 		const float flAdjustedLatency = std::clamp((flRealLatency + (bFakeLatency ? flFakeLatency : 0.f)), 0.f, 1.f);
 		return flAdjustedLatency;

--- a/Fedoraware/TeamFortress2/TeamFortress2/Features/Backtrack/Backtrack.cpp
+++ b/Fedoraware/TeamFortress2/TeamFortress2/Features/Backtrack/Backtrack.cpp
@@ -105,8 +105,8 @@ float CBacktrackNew::GetLatency()
 {
 	if (INetChannel* iNetChan = I::EngineClient->GetNetChannelInfo()){
 		const float flRealLatency = iNetChan->GetLatency(FLOW_OUTGOING);
-		const float flFakeLatency = (float)std::clamp(Vars::Backtrack::Latency.Value, 0, 800) / 1000.f;
-		const float flAdjustedLatency = flLatencyRampup * std::clamp((flRealLatency + (bFakeLatency ? flFakeLatency : 0.f)), 0.f, 1.f);
+		const float flFakeLatency = flLatencyRampup * std::clamp((float)Vars::Backtrack::Latency.Value, 0.f, 800.f) / 1000.f;
+		const float flAdjustedLatency = std::clamp((flRealLatency + (bFakeLatency ? flFakeLatency : 0.f)), 0.f, 1.f);
 		return flAdjustedLatency;
 	}
 

--- a/Fedoraware/TeamFortress2/TeamFortress2/Features/Backtrack/Backtrack.cpp
+++ b/Fedoraware/TeamFortress2/TeamFortress2/Features/Backtrack/Backtrack.cpp
@@ -99,12 +99,12 @@ void CBacktrackNew::Restart(){
 	iLastInSequence = 0;
 }
 
-void CBacktrackNew::CLMove(){
+void CBacktrackNew::FrameStageNotify(){
 	CBaseEntity* pLocal = g_EntityCache.GetLocal();
 	INetChannel* iNetChan = I::EngineClient->GetNetChannelInfo();
 	if (!pLocal || !iNetChan) { return Restart(); }
 
-	flLatencyRampup = std::min(1.f, flLatencyRampup + I::GlobalVars->interval_per_tick);
+	flLatencyRampup = std::min(1.f, flLatencyRampup += I::GlobalVars->interval_per_tick);
 	UpdateDatagram();
 	MakeRecords();
 	CleanRecords();

--- a/Fedoraware/TeamFortress2/TeamFortress2/Features/Backtrack/Backtrack.cpp
+++ b/Fedoraware/TeamFortress2/TeamFortress2/Features/Backtrack/Backtrack.cpp
@@ -4,6 +4,15 @@ bool CBacktrackNew::IsTracked(TickRecordNew Record){
 	return I::GlobalVars->curtime - Record.flCreateTime < 1.f;
 }
 
+//	should return true if the current position on the client has a lag comp record created for it by the server (SHOULD)
+//	if the player has updated more than once, only the first update will have a backtrack record (i think)
+//	dont use this yet
+bool CBacktrackNew::IsSimulationReliable(CBaseEntity* pEntity){
+	const float flSimTimeDelta = pEntity->GetSimulationTime() - pEntity->GetOldSimulationTime();
+	const int iTicksSimTimeDelta = flSimTimeDelta / I::GlobalVars->interval_per_tick;
+	return iTicksSimTimeDelta == 1;
+}
+
 bool CBacktrackNew::WithinRewind(TickRecordNew Record){	//	check if we can go to this tick, ie, within 200ms of us
 	CBaseEntity* pLocal = g_EntityCache.GetLocal();
 	INetChannel* iNetChan = I::EngineClient->GetNetChannelInfo();
@@ -33,6 +42,9 @@ void CBacktrackNew::CleanRecords(){
 void CBacktrackNew::MakeRecords(){
 	const float flCurTime = I::GlobalVars->curtime;
 	const int iTickcount = I::GlobalVars->tickcount;
+	if (iLastCreationTick == iTickcount) { return; }
+	iLastCreationTick = iTickcount;
+
 	for (int n = 1; n < I::ClientEntityList->GetHighestEntityIndex(); n++)
 	{
 		CBaseEntity* pEntity = I::ClientEntityList->GetClientEntity(n);

--- a/Fedoraware/TeamFortress2/TeamFortress2/Features/Backtrack/Backtrack.cpp
+++ b/Fedoraware/TeamFortress2/TeamFortress2/Features/Backtrack/Backtrack.cpp
@@ -176,6 +176,16 @@ std::deque<TickRecordNew>* CBacktrackNew::GetRecords(CBaseEntity* pEntity){
 	return &mRecords[pEntity];
 }
 
+std::optional<TickRecordNew> CBacktrackNew::GetLastRecord(CBaseEntity* pEntity){
+	if (mRecords[pEntity].empty()) { return std::nullopt; }
+	std::optional<TickRecordNew> rReturnRecord = std::nullopt;
+	for (const auto& rCurQuery : mRecords[pEntity]){
+		if (!IsTracked(rCurQuery) || !WithinRewind(rCurQuery)) { continue; }
+		rReturnRecord = rCurQuery;
+	}
+	return rReturnRecord;
+}
+
 // Adjusts the fake latency ping
 void CBacktrackNew::AdjustPing(INetChannel* netChannel)
 {

--- a/Fedoraware/TeamFortress2/TeamFortress2/Features/Backtrack/Backtrack.cpp
+++ b/Fedoraware/TeamFortress2/TeamFortress2/Features/Backtrack/Backtrack.cpp
@@ -130,9 +130,7 @@ void CBacktrackNew::FrameStageNotify(){
 void CBacktrackNew::ReportShot(int iIndex){
 	CBaseEntity* pEntity = I::ClientEntityList->GetClientEntity(iIndex);
 	if (!pEntity) { return; }
-	CBaseCombatWeapon* pWeapon = pEntity->GetActiveWeapon();
-	if (!pWeapon) { return; }
-	mDidShoot[pEntity->GetIndex()] = Utils::GetWeaponType(pWeapon) == EWeaponType::HITSCAN;
+	mDidShoot[pEntity->GetIndex()] = true;
 }
 
 std::optional<TickRecordNew> CBacktrackNew::GetHitRecord(CUserCmd* pCmd, CBaseEntity* pEntity, const Vec3 vAngles, const Vec3 vPos){

--- a/Fedoraware/TeamFortress2/TeamFortress2/Features/Backtrack/Backtrack.cpp
+++ b/Fedoraware/TeamFortress2/TeamFortress2/Features/Backtrack/Backtrack.cpp
@@ -141,7 +141,7 @@ std::optional<TickRecordNew> CBacktrackNew::Run(CUserCmd* pCmd, bool bAimbot = f
 		if (mRecords[pEntity].empty()) { return std::nullopt; }
 		std::optional<TickRecordNew> rReturnRecord = std::nullopt;
 		for (const auto& rCurQuery : mRecords[pEntity]){
-			if (!IsTracked(rCurQuery) || !WithinRewind(rCurQuery) || !IsLagComped(rCurQuery, pEntity)) { continue; }	//	this record is borked :D
+			if (!IsTracked(rCurQuery) || !WithinRewind(rCurQuery)) { continue; }	//	this record is borked :D
 			if (rCurQuery.bOnShot) { rReturnRecord = rCurQuery; break; }	//	this record is an onshot record
 			rReturnRecord = rCurQuery;	//	nothing special, continue
 		}

--- a/Fedoraware/TeamFortress2/TeamFortress2/Features/Backtrack/Backtrack.cpp
+++ b/Fedoraware/TeamFortress2/TeamFortress2/Features/Backtrack/Backtrack.cpp
@@ -154,6 +154,7 @@ std::pair<std::optional<TickRecordNew>, float> CBacktrackNew::GetClosestRecord(C
 }
 
 std::optional<TickRecordNew> CBacktrackNew::Run(CUserCmd* pCmd = nullptr, bool bAimbot = false, CBaseEntity* pEntity = nullptr){
+	if (!Vars::Backtrack::Enabled.Value) { return std::nullopt; }
 	static int iOldTickCount = I::GlobalVars->tickcount;
 	const int iCurTickCount = I::GlobalVars->tickcount;
 	static int iLastIndex = 0;

--- a/Fedoraware/TeamFortress2/TeamFortress2/Features/Backtrack/Backtrack.h
+++ b/Fedoraware/TeamFortress2/TeamFortress2/Features/Backtrack/Backtrack.h
@@ -63,6 +63,7 @@ class CBacktrackNew
 private:
 	//	logic
 	bool IsTracked(TickRecordNew Record);
+	bool IsSimulationReliable(CBaseEntity* pEntity);
 	//bool IsBackLagComped(CBaseEntity* pEntity);
 
 	//	utils
@@ -76,6 +77,7 @@ private:
 	//	data
 	std::unordered_map<CBaseEntity*, std::deque<TickRecordNew>> mRecords;
 	std::unordered_map<int, bool> mDidShoot;
+	int iLastCreationTick = 0;
 
 	//	data - fake latency
 	std::deque<CIncomingSequence> dSequences;

--- a/Fedoraware/TeamFortress2/TeamFortress2/Features/Backtrack/Backtrack.h
+++ b/Fedoraware/TeamFortress2/TeamFortress2/Features/Backtrack/Backtrack.h
@@ -61,11 +61,11 @@ private:
 
 	//	utils
 	void CleanRecords();
+	void MakeRecords();
 
 	std::unordered_map<int, bool> mDidShoot;
-	std::unordered_map<CBaseEntity*, std::vector<TickRecordNew>> mRecords;
+	std::unordered_map<CBaseEntity*, std::deque<TickRecordNew>> mRecords;
 public:
-	void SimTimeChanged(void* pEntity, float flSimtime);
 	void Restart();	//	called whenever lol
 	void FrameStageNotify();	//	called in FRAME_NET_UPDATE_END
 	void ReportShot(int iIndex, void* pWpn);

--- a/Fedoraware/TeamFortress2/TeamFortress2/Features/Backtrack/Backtrack.h
+++ b/Fedoraware/TeamFortress2/TeamFortress2/Features/Backtrack/Backtrack.h
@@ -64,6 +64,7 @@ private:
 	//	utils
 	void CleanRecords();
 	void MakeRecords();
+	std::pair<std::optional<TickRecordNew>, float> GetClosestRecord(CUserCmd* pCmd, CBaseEntity* pEntity, const Vec3 vAngles, const Vec3 vPos);
 	//	utils - fake latency
 	void UpdateDatagram();
 	float GetLatency();

--- a/Fedoraware/TeamFortress2/TeamFortress2/Features/Backtrack/Backtrack.h
+++ b/Fedoraware/TeamFortress2/TeamFortress2/Features/Backtrack/Backtrack.h
@@ -57,21 +57,30 @@ class CBacktrackNew
 private:
 	//	logic
 	bool IsTracked(TickRecordNew Record);
-	bool WithinRewind(TickRecordNew Record);
 
 	//	utils
 	void CleanRecords();
 	void MakeRecords();
+	//	utils - fake latency
+	void UpdateDatagram();
+	float GetLatency();
 
+	//	data
 	std::unordered_map<int, bool> mDidShoot;
 	std::unordered_map<CBaseEntity*, std::deque<TickRecordNew>> mRecords;
+	//	data - fake latency
+	std::deque<CIncomingSequence> dSequences;
+	float flLatencyRampup = 0.f;
+	int iLastInSequence = 0;
 public:
+	bool WithinRewind(TickRecordNew Record);
 	void Restart();	//	called whenever lol
 	void CLMove();	//	called in CLMove
 	void ReportShot(int iIndex, void* pWpn);
 	std::deque<TickRecordNew>* GetRecords(CBaseEntity* pEntity);
-	std::optional<TickRecordNew> GetRecord(CBaseEntity* pEntity, BacktrackMode bMode);
-	TickRecordNew Run(CUserCmd* pCmd, bool bAimbot, CBaseEntity* pEntity);	//	returns the best record
+	std::optional<TickRecordNew> Run(CUserCmd* pCmd, bool bAimbot, CBaseEntity* pEntity);	//	returns a valid record
+	void AdjustPing(INetChannel* netChannel);	//	blurgh
+	bool bFakeLatency = false;
 };
 
 class CBacktrack
@@ -84,7 +93,7 @@ class CBacktrack
 
 	float LatencyRampup = 0.f;
 	int LastInSequence = 0;
-	std::deque<CIncomingSequence> Sequences;
+	
 
 public:
 	//void Run();

--- a/Fedoraware/TeamFortress2/TeamFortress2/Features/Backtrack/Backtrack.h
+++ b/Fedoraware/TeamFortress2/TeamFortress2/Features/Backtrack/Backtrack.h
@@ -59,7 +59,7 @@ class CBacktrackNew
 private:
 	//	logic
 	bool IsTracked(TickRecordNew Record);
-	bool IsLagComped(TickRecordNew Record, CBaseEntity* pEntity);
+	bool IsBackLagComped(CBaseEntity* pEntity);
 
 	//	utils
 	void CleanRecords();

--- a/Fedoraware/TeamFortress2/TeamFortress2/Features/Backtrack/Backtrack.h
+++ b/Fedoraware/TeamFortress2/TeamFortress2/Features/Backtrack/Backtrack.h
@@ -45,6 +45,8 @@ struct TickRecordNew{
 	int iTickCount = 0;
 	bool bOnShot = false;
 	BoneMatrixes BoneMatrix{};
+	Vec3 vOrigin = {};
+	Vec3 vAngles = {};
 };
 
 enum class BacktrackMode
@@ -57,6 +59,7 @@ class CBacktrackNew
 private:
 	//	logic
 	bool IsTracked(TickRecordNew Record);
+	bool IsLagComped(TickRecordNew Record, CBaseEntity* pEntity);
 
 	//	utils
 	void CleanRecords();

--- a/Fedoraware/TeamFortress2/TeamFortress2/Features/Backtrack/Backtrack.h
+++ b/Fedoraware/TeamFortress2/TeamFortress2/Features/Backtrack/Backtrack.h
@@ -74,7 +74,6 @@ private:
 	float GetLatency();
 
 	//	data
-	std::unordered_map<int, bool> mDidShoot;
 	std::unordered_map<CBaseEntity*, std::deque<TickRecordNew>> mRecords;
 	//	data - fake latency
 	std::deque<CIncomingSequence> dSequences;
@@ -93,6 +92,7 @@ public:
 	std::optional<TickRecordNew> Run(CUserCmd* pCmd);	//	returns a valid record
 	void AdjustPing(INetChannel* netChannel);	//	blurgh
 	bool bFakeLatency = false;
+	std::unordered_map<int, bool> mDidShoot;
 };
 
 class CBacktrack

--- a/Fedoraware/TeamFortress2/TeamFortress2/Features/Backtrack/Backtrack.h
+++ b/Fedoraware/TeamFortress2/TeamFortress2/Features/Backtrack/Backtrack.h
@@ -59,7 +59,7 @@ class CBacktrackNew
 private:
 	//	logic
 	bool IsTracked(TickRecordNew Record);
-	bool IsBackLagComped(CBaseEntity* pEntity);
+	//bool IsBackLagComped(CBaseEntity* pEntity);
 
 	//	utils
 	void CleanRecords();
@@ -77,6 +77,7 @@ private:
 	int iLastInSequence = 0;
 public:
 	bool WithinRewind(TickRecordNew Record);
+	void PlayerHurt(CGameEvent* pEvent);	//	called on player_hurt event
 	void Restart();	//	called whenever lol
 	void FrameStageNotify();	//	called in FrameStageNotify
 	void ReportShot(int iIndex, void* pWpn);

--- a/Fedoraware/TeamFortress2/TeamFortress2/Features/Backtrack/Backtrack.h
+++ b/Fedoraware/TeamFortress2/TeamFortress2/Features/Backtrack/Backtrack.h
@@ -75,7 +75,7 @@ private:
 public:
 	bool WithinRewind(TickRecordNew Record);
 	void Restart();	//	called whenever lol
-	void CLMove();	//	called in CLMove
+	void FrameStageNotify();	//	called in FrameStageNotify
 	void ReportShot(int iIndex, void* pWpn);
 	std::deque<TickRecordNew>* GetRecords(CBaseEntity* pEntity);
 	std::optional<TickRecordNew> Run(CUserCmd* pCmd, bool bAimbot, CBaseEntity* pEntity);	//	returns a valid record

--- a/Fedoraware/TeamFortress2/TeamFortress2/Features/Backtrack/Backtrack.h
+++ b/Fedoraware/TeamFortress2/TeamFortress2/Features/Backtrack/Backtrack.h
@@ -67,8 +67,10 @@ private:
 	std::unordered_map<CBaseEntity*, std::deque<TickRecordNew>> mRecords;
 public:
 	void Restart();	//	called whenever lol
-	void FrameStageNotify();	//	called in FRAME_NET_UPDATE_END
+	void CLMove();	//	called in CLMove
 	void ReportShot(int iIndex, void* pWpn);
+	std::deque<TickRecordNew>* GetRecords(CBaseEntity* pEntity);
+	std::optional<TickRecordNew> GetRecord(CBaseEntity* pEntity, BacktrackMode bMode);
 	TickRecordNew Run(CUserCmd* pCmd, bool bAimbot, CBaseEntity* pEntity);	//	returns the best record
 };
 

--- a/Fedoraware/TeamFortress2/TeamFortress2/Features/Backtrack/Backtrack.h
+++ b/Fedoraware/TeamFortress2/TeamFortress2/Features/Backtrack/Backtrack.h
@@ -82,6 +82,7 @@ public:
 	void FrameStageNotify();	//	called in FrameStageNotify
 	void ReportShot(int iIndex, void* pWpn);
 	std::deque<TickRecordNew>* GetRecords(CBaseEntity* pEntity);
+	std::optional<TickRecordNew> GetLastRecord(CBaseEntity* pEntity);
 	std::optional<TickRecordNew> Run(CUserCmd* pCmd, bool bAimbot, CBaseEntity* pEntity);	//	returns a valid record
 	void AdjustPing(INetChannel* netChannel);	//	blurgh
 	bool bFakeLatency = false;

--- a/Fedoraware/TeamFortress2/TeamFortress2/Features/Backtrack/Backtrack.h
+++ b/Fedoraware/TeamFortress2/TeamFortress2/Features/Backtrack/Backtrack.h
@@ -75,6 +75,8 @@ private:
 
 	//	data
 	std::unordered_map<CBaseEntity*, std::deque<TickRecordNew>> mRecords;
+	std::unordered_map<int, bool> mDidShoot;
+
 	//	data - fake latency
 	std::deque<CIncomingSequence> dSequences;
 	float flLatencyRampup = 0.f;
@@ -92,7 +94,6 @@ public:
 	std::optional<TickRecordNew> Run(CUserCmd* pCmd);	//	returns a valid record
 	void AdjustPing(INetChannel* netChannel);	//	blurgh
 	bool bFakeLatency = false;
-	std::unordered_map<int, bool> mDidShoot;
 };
 
 class CBacktrack

--- a/Fedoraware/TeamFortress2/TeamFortress2/Features/ESP/ESP.cpp
+++ b/Fedoraware/TeamFortress2/TeamFortress2/Features/ESP/ESP.cpp
@@ -1439,7 +1439,7 @@ std::vector<std::wstring> CESP::GetPlayerConds(CBaseEntity* pEntity) const
 		szCond.emplace_back(L"Burning");
 	}
 
-	if (nCond & TFCond_Ubercharged || nCondEx & TFCondEx_PhlogUber || nCondEx & TFCondEx_UberchargedCanteen || nCondEx & TFCondEx_UberchargedHidden)
+	if (pEntity->IsUbered())
 	{
 		szCond.emplace_back(L"Ubered");
 	}

--- a/Fedoraware/TeamFortress2/TeamFortress2/Features/Menu/ConfigManager/ConfigManager.cpp
+++ b/Fedoraware/TeamFortress2/TeamFortress2/Features/Menu/ConfigManager/ConfigManager.cpp
@@ -862,6 +862,20 @@ bool CConfigManager::SaveConfig(const std::string& configName)
 				SAVE_VAR(Vars::Misc::Followbot::Distance);
 			}
 
+			// Cheater Detection
+			{
+				SAVE_VAR(Vars::Misc::CheaterDetection::Enabled);
+				SAVE_VAR(Vars::Misc::CheaterDetection::Methods);
+				SAVE_VAR(Vars::Misc::CheaterDetection::Protections);
+				SAVE_VAR(Vars::Misc::CheaterDetection::SuspicionGate);
+				SAVE_VAR(Vars::Misc::CheaterDetection::PacketManipGate);
+				SAVE_VAR(Vars::Misc::CheaterDetection::BHopMaxDelay);
+				SAVE_VAR(Vars::Misc::CheaterDetection::BHopDetectionsRequired);
+				SAVE_VAR(Vars::Misc::CheaterDetection::ScoreMultiplier);
+				SAVE_VAR(Vars::Misc::CheaterDetection::MinimumFlickDistance);
+				SAVE_VAR(Vars::Misc::CheaterDetection::MaximumNoise);
+			}
+
 			// CL_Move
 			{
 				SAVE_VAR(Vars::Misc::CL_Move::Enabled); //Enabled
@@ -1698,6 +1712,20 @@ bool CConfigManager::LoadConfig(const std::string& configName)
 			{
 				LOAD_VAR(Vars::Misc::Followbot::Enabled);
 				LOAD_VAR(Vars::Misc::Followbot::Distance);
+			}
+
+			// Cheater Detection
+			{
+				LOAD_VAR(Vars::Misc::CheaterDetection::Enabled);
+				LOAD_VAR(Vars::Misc::CheaterDetection::Methods);
+				LOAD_VAR(Vars::Misc::CheaterDetection::Protections);
+				LOAD_VAR(Vars::Misc::CheaterDetection::SuspicionGate);
+				LOAD_VAR(Vars::Misc::CheaterDetection::PacketManipGate);
+				LOAD_VAR(Vars::Misc::CheaterDetection::BHopMaxDelay);
+				LOAD_VAR(Vars::Misc::CheaterDetection::BHopDetectionsRequired);
+				LOAD_VAR(Vars::Misc::CheaterDetection::ScoreMultiplier);
+				LOAD_VAR(Vars::Misc::CheaterDetection::MinimumFlickDistance);
+				LOAD_VAR(Vars::Misc::CheaterDetection::MaximumNoise);
 			}
 
 			// CL_Move

--- a/Fedoraware/TeamFortress2/TeamFortress2/Features/Menu/ConfigManager/ConfigManager.cpp
+++ b/Fedoraware/TeamFortress2/TeamFortress2/Features/Menu/ConfigManager/ConfigManager.cpp
@@ -824,6 +824,7 @@ bool CConfigManager::SaveConfig(const std::string& configName)
 			SAVE_VAR(Vars::Misc::Directional);
 			SAVE_VAR(Vars::Misc::EdgeJump);
 			SAVE_VAR(Vars::Misc::EdgeJumpKey);
+			SAVE_VAR(Vars::Misc::StoreStatistics);
 			SAVE_VAR(Vars::Misc::AntiAFK);
 			SAVE_VAR(Vars::Misc::CheatsBypass);
 			SAVE_VAR(Vars::Misc::RageRetry);
@@ -1651,6 +1652,7 @@ bool CConfigManager::LoadConfig(const std::string& configName)
 			LOAD_VAR(Vars::Misc::NoPush);
 			LOAD_VAR(Vars::Misc::EdgeJump);
 			LOAD_VAR(Vars::Misc::EdgeJumpKey);
+			LOAD_VAR(Vars::Misc::StoreStatistics);
 			LOAD_VAR(Vars::Misc::AutoStrafe);
 			LOAD_VAR(Vars::Misc::Directional);
 			LOAD_VAR(Vars::Misc::AntiAFK);

--- a/Fedoraware/TeamFortress2/TeamFortress2/Features/Menu/ConfigManager/ConfigManager.cpp
+++ b/Fedoraware/TeamFortress2/TeamFortress2/Features/Menu/ConfigManager/ConfigManager.cpp
@@ -330,6 +330,7 @@ bool CConfigManager::SaveConfig(const std::string& configName)
 				SAVE_VAR(Vars::Aimbot::Hitscan::TapFire);
 				SAVE_VAR(Vars::Aimbot::Hitscan::ScanHitboxes);
 				SAVE_VAR(Vars::Aimbot::Hitscan::MultiHitboxes);
+				SAVE_VAR(Vars::Aimbot::Hitscan::StaticHitboxes);
 				SAVE_VAR(Vars::Aimbot::Hitscan::PointScale);
 				SAVE_VAR(Vars::Aimbot::Hitscan::ScanBuildings);
 				SAVE_VAR(Vars::Aimbot::Hitscan::WaitForHeadshot);
@@ -1160,6 +1161,7 @@ bool CConfigManager::LoadConfig(const std::string& configName)
 				LOAD_VAR(Vars::Aimbot::Hitscan::TapFire);
 				LOAD_VAR(Vars::Aimbot::Hitscan::ScanHitboxes);
 				LOAD_VAR(Vars::Aimbot::Hitscan::MultiHitboxes);
+				LOAD_VAR(Vars::Aimbot::Hitscan::StaticHitboxes);
 				LOAD_VAR(Vars::Aimbot::Hitscan::PointScale);
 				LOAD_VAR(Vars::Aimbot::Hitscan::ScanBuildings);
 				LOAD_VAR(Vars::Aimbot::Hitscan::WaitForHeadshot);

--- a/Fedoraware/TeamFortress2/TeamFortress2/Features/Menu/ConfigManager/ConfigManager.cpp
+++ b/Fedoraware/TeamFortress2/TeamFortress2/Features/Menu/ConfigManager/ConfigManager.cpp
@@ -874,6 +874,8 @@ bool CConfigManager::SaveConfig(const std::string& configName)
 				SAVE_VAR(Vars::Misc::CheaterDetection::ScoreMultiplier);
 				SAVE_VAR(Vars::Misc::CheaterDetection::MinimumFlickDistance);
 				SAVE_VAR(Vars::Misc::CheaterDetection::MaximumNoise);
+				SAVE_VAR(Vars::Misc::CheaterDetection::MinimumAimbotFoV);
+				SAVE_VAR(Vars::Misc::CheaterDetection::MaxScaledAimbotFoV);
 			}
 
 			// CL_Move
@@ -1726,6 +1728,8 @@ bool CConfigManager::LoadConfig(const std::string& configName)
 				LOAD_VAR(Vars::Misc::CheaterDetection::ScoreMultiplier);
 				LOAD_VAR(Vars::Misc::CheaterDetection::MinimumFlickDistance);
 				LOAD_VAR(Vars::Misc::CheaterDetection::MaximumNoise);
+				LOAD_VAR(Vars::Misc::CheaterDetection::MinimumAimbotFoV);
+				LOAD_VAR(Vars::Misc::CheaterDetection::MaxScaledAimbotFoV);
 			}
 
 			// CL_Move

--- a/Fedoraware/TeamFortress2/TeamFortress2/Features/Menu/ConfigManager/ConfigManager.cpp
+++ b/Fedoraware/TeamFortress2/TeamFortress2/Features/Menu/ConfigManager/ConfigManager.cpp
@@ -867,6 +867,8 @@ bool CConfigManager::SaveConfig(const std::string& configName)
 				SAVE_VAR(Vars::Misc::CL_Move::Enabled); //Enabled
 				SAVE_VAR(Vars::Misc::CL_Move::Doubletap); // { true, L"Doubletap" };
 				SAVE_VAR(Vars::Misc::CL_Move::SafeTick);
+				SAVE_VAR(Vars::Misc::CL_Move::SafeTickAirOverride);
+				SAVE_VAR(Vars::Misc::CL_Move::PassiveRecharge);
 				SAVE_VAR(Vars::Misc::CL_Move::WaitForDT); // { true, L"Doubletap" };
 				SAVE_VAR(Vars::Misc::CL_Move::NotInAir); // { true, L"Doubletap" };
 				SAVE_VAR(Vars::Misc::CL_Move::StopMovement);
@@ -885,6 +887,11 @@ bool CConfigManager::SaveConfig(const std::string& configName)
 				SAVE_VAR(Vars::Misc::CL_Move::FakelagMin);
 				SAVE_VAR(Vars::Misc::CL_Move::FakelagMax);
 				SAVE_VAR(Vars::Misc::CL_Move::FakelagMode);
+				SAVE_VAR(Vars::Misc::CL_Move::WhileMoving);
+				SAVE_VAR(Vars::Misc::CL_Move::WhileInAir);
+				SAVE_VAR(Vars::Misc::CL_Move::WhileUnducking);
+				SAVE_VAR(Vars::Misc::CL_Move::WhileVisible);
+				SAVE_VAR(Vars::Misc::CL_Move::PredictVisibility);
 				SAVE_VAR(Vars::Misc::CL_Move::FakelagOnKey); // { 0x52, L"Recharge Key" }; //
 				SAVE_VAR(Vars::Misc::CL_Move::FakelagKey); // { 0x52, L"Recharge Key" }; //R
 				SAVE_VAR(Vars::Misc::CL_Move::FakelagValue); // { 0x52, L"Recharge Key" }; //R
@@ -1698,6 +1705,8 @@ bool CConfigManager::LoadConfig(const std::string& configName)
 				LOAD_VAR(Vars::Misc::CL_Move::Enabled); //Enabled
 				LOAD_VAR(Vars::Misc::CL_Move::Doubletap); // { true, L"Doubletap" };
 				LOAD_VAR(Vars::Misc::CL_Move::SafeTick);
+				LOAD_VAR(Vars::Misc::CL_Move::SafeTickAirOverride);
+				LOAD_VAR(Vars::Misc::CL_Move::PassiveRecharge);
 				LOAD_VAR(Vars::Misc::CL_Move::WaitForDT); // { true, L"Doubletap" };
 				LOAD_VAR(Vars::Misc::CL_Move::NotInAir); // { true, L"Doubletap" };
 				LOAD_VAR(Vars::Misc::CL_Move::StopMovement);
@@ -1716,6 +1725,11 @@ bool CConfigManager::LoadConfig(const std::string& configName)
 				LOAD_VAR(Vars::Misc::CL_Move::FakelagMin);
 				LOAD_VAR(Vars::Misc::CL_Move::FakelagMax);
 				LOAD_VAR(Vars::Misc::CL_Move::FakelagMode);
+				LOAD_VAR(Vars::Misc::CL_Move::WhileMoving);
+				LOAD_VAR(Vars::Misc::CL_Move::WhileInAir);
+				LOAD_VAR(Vars::Misc::CL_Move::WhileUnducking);
+				LOAD_VAR(Vars::Misc::CL_Move::WhileVisible);
+				LOAD_VAR(Vars::Misc::CL_Move::PredictVisibility);
 				LOAD_VAR(Vars::Misc::CL_Move::FakelagOnKey); // { 0x52, L"Recharge Key" }; //R
 				LOAD_VAR(Vars::Misc::CL_Move::FakelagKey); // { 0x52, L"Recharge Key" }; //R
 				LOAD_VAR(Vars::Misc::CL_Move::FakelagValue); // { 0x52, L"Recharge Key" }; //R

--- a/Fedoraware/TeamFortress2/TeamFortress2/Features/Menu/Menu.cpp
+++ b/Fedoraware/TeamFortress2/TeamFortress2/Features/Menu/Menu.cpp
@@ -326,6 +326,11 @@ void CMenu::MenuAimbot()
 				static std::vector flagValues{ 0x00000001, 0x00000004, 0x00000002, 0x00000008, 0x00000010 }; // 1<<1 and 1<<2 are swapped because the enum for hitboxes is weird.
 				MultiFlags(flagNames, flagValues, &Vars::Aimbot::Hitscan::MultiHitboxes.Value, "Multipoint Hitboxes###AimbotMultipointScanning");
 			}
+			{
+				static std::vector flagNames{ "Head", "Body", "Pelvis", "Arms", "Legs" };
+				static std::vector flagValues{ 0x00000001, 0x00000004, 0x00000002, 0x00000008, 0x00000010 }; // 1<<1 and 1<<2 are swapped because the enum for hitboxes is weird.
+				MultiFlags(flagNames, flagValues, &Vars::Aimbot::Hitscan::StaticHitboxes.Value, "Static Hitboxes###AimbotStaticOnlyScanning");
+			}
 			WSlider("Point Scale###HitscanMultipointScale", &Vars::Aimbot::Hitscan::PointScale.Value, 0.5f, 1.f, "%.2f", ImGuiSliderFlags_AlwaysClamp);
 			WToggle("Buildings Multipoint", &Vars::Aimbot::Hitscan::ScanBuildings.Value); HelpMarker("Scans the building hitbox to improve hitchance");
 			WToggle("Wait for headshot", &Vars::Aimbot::Hitscan::WaitForHeadshot.Value); HelpMarker("The aimbot will wait until it can headshot (if applicable)");

--- a/Fedoraware/TeamFortress2/TeamFortress2/Features/Menu/Menu.cpp
+++ b/Fedoraware/TeamFortress2/TeamFortress2/Features/Menu/Menu.cpp
@@ -1522,8 +1522,8 @@ void CMenu::MenuHvH()
 			WToggle("Enable Cheater Detection", &Vars::Misc::CheaterDetection::Enabled.Value);
 			if (Vars::Misc::CheaterDetection::Enabled.Value){
 				{
-					static std::vector flagNames{ "Accuracy", "Score", "Simtime Changes", "Packet Choking", "Bunnyhopping", "Aim Flicking & Aimbot", "OOB Angles" };
-					static std::vector flagValues{ 1 << 0, 1 << 1, 1 << 2, 1 << 3, 1 << 4, 1 << 5, 1 << 6 };
+					static std::vector flagNames{ "Accuracy", "Score", "Simtime Changes", "Packet Choking", "Bunnyhopping", "Aim Flicking & Aimbot", "OOB Angles", "Aimbot", "Duck Speed" };
+					static std::vector flagValues{ 1 << 0, 1 << 1, 1 << 2, 1 << 3, 1 << 4, 1 << 5, 1 << 6, 1 << 7, 1 << 8 };
 					MultiFlags(flagNames, flagValues, &Vars::Misc::CheaterDetection::Methods.Value, "Detection Methods###CheaterDetectionMethods");
 					HelpMarker("Methods by which to detect bad actors.");
 				}
@@ -1549,6 +1549,11 @@ void CMenu::MenuHvH()
 				if (Vars::Misc::CheaterDetection::Methods.Value & (1<<5)) {
 					WSlider("Minimum Aim-Flick", &Vars::Misc::CheaterDetection::MinimumFlickDistance.Value, 5.f, 30.f, "%.1f"); HelpMarker("The distance someones view angles must flick prior to be being suspected by the cheat detector."); 
 					WSlider("Maximum Post Flick Noise", &Vars::Misc::CheaterDetection::MaximumNoise.Value, 5.f, 15.f, "%.1f"); HelpMarker("The maximum distance the players mouse can move post-flick before the cheat detector considers it as a legit flick (mouse moved fast, etc)."); 
+				}
+
+				if (Vars::Misc::CheaterDetection::Methods.Value & (1<<7)){
+					WSlider("Maximum Scaled Aimbot FoV", &Vars::Misc::CheaterDetection::MaxScaledAimbotFoV.Value, 5.f, 30.f, "%.1f"); HelpMarker("The maximum FoV (post scaling) for the aimbot detection."); 
+					WSlider("Minimum Aimbot FoV", &Vars::Misc::CheaterDetection::MinimumAimbotFoV.Value, 5.f, 30.f, "%.1f"); HelpMarker("The minimum FoV to infract a player for aimbot."); 
 				}
 			}
 			SectionTitle("Resolver");

--- a/Fedoraware/TeamFortress2/TeamFortress2/Features/Menu/Menu.cpp
+++ b/Fedoraware/TeamFortress2/TeamFortress2/Features/Menu/Menu.cpp
@@ -1483,11 +1483,12 @@ void CMenu::MenuHvH()
 			if (Vars::Misc::CL_Move::TeleportMode.Value) {
 				WSlider("Smooth Teleport Factor", &Vars::Misc::CL_Move::TeleportFactor.Value, 2, 6, "%d");
 			}
-			MultiCombo({ "Recharge While Dead", "Auto Recharge", "Wait for DT", "Anti-warp", "Avoid airborne", "Retain Fakelag", "Stop Recharge Movement", "Safe Tick" }, { &Vars::Misc::CL_Move::RechargeWhileDead.Value, &Vars::Misc::CL_Move::AutoRecharge.Value, &Vars::Misc::CL_Move::WaitForDT.Value, &Vars::Misc::CL_Move::AntiWarp.Value, &Vars::Misc::CL_Move::NotInAir.Value, &Vars::Misc::CL_Move::RetainFakelag.Value, &Vars::Misc::CL_Move::StopMovement.Value, &Vars::Misc::CL_Move::SafeTick.Value }, "Options");
+			MultiCombo({ "Recharge While Dead", "Auto Recharge", "Wait for DT", "Anti-warp", "Avoid airborne", "Retain Fakelag", "Stop Recharge Movement", "Safe Tick", "Safe Tick Airborne" }, { &Vars::Misc::CL_Move::RechargeWhileDead.Value, &Vars::Misc::CL_Move::AutoRecharge.Value, &Vars::Misc::CL_Move::WaitForDT.Value, &Vars::Misc::CL_Move::AntiWarp.Value, &Vars::Misc::CL_Move::NotInAir.Value, &Vars::Misc::CL_Move::RetainFakelag.Value, &Vars::Misc::CL_Move::StopMovement.Value, &Vars::Misc::CL_Move::SafeTick.Value, &Vars::Misc::CL_Move::SafeTickAirOverride.Value }, "Options");
 			HelpMarker("Enable various features regarding tickbase exploits");
 			WCombo("Doubletap Mode", &Vars::Misc::CL_Move::DTMode.Value, { "On key", "Always", "Disable on key", "Disabled" }); HelpMarker("How should DT behave");
 			const int ticksMax = g_ConVars.sv_maxusrcmdprocessticks->GetInt() - 2;
 			WSlider("Ticks to shift", &Vars::Misc::CL_Move::DTTicks.Value, 1, ticksMax ? ticksMax : 22, "%d"); HelpMarker("How many ticks to shift");
+			WSlider("Passive Recharge Factor", &Vars::Misc::CL_Move::PassiveRecharge.Value, 0, 22, "%d");
 			WToggle("SpeedHack", &Vars::Misc::CL_Move::SEnabled.Value); HelpMarker("Speedhack Master Switch");
 			if (Vars::Misc::CL_Move::SEnabled.Value)
 			{
@@ -1498,7 +1499,7 @@ void CMenu::MenuHvH()
 			/* Section: Fakelag */
 			SectionTitle("Fakelag");
 			WToggle("Enable Fakelag", &Vars::Misc::CL_Move::Fakelag.Value);
-			MultiCombo({ "While Moving", "On Key", "While Visible", "Predict Visibility", "While Unducking" }, { &Vars::Misc::CL_Move::WhileMoving.Value, &Vars::Misc::CL_Move::FakelagOnKey.Value, &Vars::Misc::CL_Move::WhileVisible.Value, &Vars::Misc::CL_Move::PredictVisibility.Value, &Vars::Misc::CL_Move::WhileUnducking.Value }, "Flags###FakeLagFlags");
+			MultiCombo({ "While Moving", "On Key", "While Visible", "Predict Visibility", "While Unducking", "While Airborne" }, { &Vars::Misc::CL_Move::WhileMoving.Value, &Vars::Misc::CL_Move::FakelagOnKey.Value, &Vars::Misc::CL_Move::WhileVisible.Value, &Vars::Misc::CL_Move::PredictVisibility.Value, &Vars::Misc::CL_Move::WhileUnducking.Value, &Vars::Misc::CL_Move::WhileInAir.Value }, "Flags###FakeLagFlags");
 			if (Vars::Misc::CL_Move::FakelagOnKey.Value)
 			{ InputKeybind("Fakelag key", Vars::Misc::CL_Move::FakelagKey); HelpMarker("The key to activate fakelag as long as it's held"); }
 			WCombo("Fakelag Mode###FLmode", &Vars::Misc::CL_Move::FakelagMode.Value, { "Plain", "Random", "Adaptive" }); HelpMarker("Controls how fakelag will be controlled.");

--- a/Fedoraware/TeamFortress2/TeamFortress2/Features/Menu/Menu.cpp
+++ b/Fedoraware/TeamFortress2/TeamFortress2/Features/Menu/Menu.cpp
@@ -302,7 +302,7 @@ void CMenu::MenuAimbot()
 			WToggle("Active", &Vars::Backtrack::Enabled.Value); HelpMarker("If you shoot at the backtrack manually it will attempt to hit it");
 			WToggle("Aimbot aims last tick", &Vars::Backtrack::LastTick.Value); HelpMarker("Aimbot aims at the last tick if visible");
 			WToggle("Fake latency", &Vars::Backtrack::FakeLatency.Value); HelpMarker("Fakes your latency to hit records further in the past");
-			WSlider("Amount of latency###BTLatency", &Vars::Backtrack::Latency.Value, 200.f, 1000.f, "%.fms", ImGuiSliderFlags_AlwaysClamp | ImGuiSliderFlags_ClampOnInput); HelpMarker("This won't work on local servers");
+			WSlider("Amount of latency###BTLatency", &Vars::Backtrack::Latency.Value, 0, 800, "%d", ImGuiSliderFlags_AlwaysClamp | ImGuiSliderFlags_ClampOnInput); HelpMarker("This won't work on local servers");
 		} EndChild();
 
 		/* Column 2 */

--- a/Fedoraware/TeamFortress2/TeamFortress2/Features/Menu/Menu.cpp
+++ b/Fedoraware/TeamFortress2/TeamFortress2/Features/Menu/Menu.cpp
@@ -1493,7 +1493,7 @@ void CMenu::MenuHvH()
 			/* Section: Fakelag */
 			SectionTitle("Fakelag");
 			WToggle("Enable Fakelag", &Vars::Misc::CL_Move::Fakelag.Value);
-			MultiCombo({ "While Moving", "On Key", "While Visible", "Predict Visibility" }, { &Vars::Misc::CL_Move::WhileMoving.Value, &Vars::Misc::CL_Move::FakelagOnKey.Value, &Vars::Misc::CL_Move::WhileVisible.Value, &Vars::Misc::CL_Move::PredictVisibility.Value }, "Flags###FakeLagFlags");
+			MultiCombo({ "While Moving", "On Key", "While Visible", "Predict Visibility", "While Unducking" }, { &Vars::Misc::CL_Move::WhileMoving.Value, &Vars::Misc::CL_Move::FakelagOnKey.Value, &Vars::Misc::CL_Move::WhileVisible.Value, &Vars::Misc::CL_Move::PredictVisibility.Value, &Vars::Misc::CL_Move::WhileUnducking.Value }, "Flags###FakeLagFlags");
 			if (Vars::Misc::CL_Move::FakelagOnKey.Value)
 			{ InputKeybind("Fakelag key", Vars::Misc::CL_Move::FakelagKey); HelpMarker("The key to activate fakelag as long as it's held"); }
 			WCombo("Fakelag Mode###FLmode", &Vars::Misc::CL_Move::FakelagMode.Value, { "Plain", "Random", "Adaptive" }); HelpMarker("Controls how fakelag will be controlled.");

--- a/Fedoraware/TeamFortress2/TeamFortress2/Features/Menu/Menu.cpp
+++ b/Fedoraware/TeamFortress2/TeamFortress2/Features/Menu/Menu.cpp
@@ -1463,7 +1463,7 @@ void CMenu::MenuVisuals()
 void CMenu::MenuHvH()
 {
 	using namespace ImGui;
-	if (BeginTable("HvHTable", 2))
+	if (BeginTable("HvHTable", 3))
 	{
 		/* Column 1 */
 		if (TableColumnChild("HvHCol1"))
@@ -1516,8 +1516,51 @@ void CMenu::MenuHvH()
 			
 		} EndChild();
 
-		/* Column 2 */
 		if (TableColumnChild("HvHCol2"))
+		{
+			SectionTitle("Cheater Detection");
+			WToggle("Enable Cheater Detection", &Vars::Misc::CheaterDetection::Enabled.Value);
+			if (Vars::Misc::CheaterDetection::Enabled.Value){
+				{
+					static std::vector flagNames{ "Accuracy", "Score", "Simtime Changes", "Packet Choking", "Bunnyhopping", "Aim Flicking & Aimbot", "OOB Angles" };
+					static std::vector flagValues{ 1 << 0, 1 << 1, 1 << 2, 1 << 3, 1 << 4, 1 << 5, 1 << 6 };
+					MultiFlags(flagNames, flagValues, &Vars::Misc::CheaterDetection::Methods.Value, "Detection Methods###CheaterDetectionMethods");
+					HelpMarker("Methods by which to detect bad actors.");
+				}
+				{
+					static std::vector flagNames{ "Double Scans", "Lagging Client", "Timing Out" };
+					static std::vector flagValues{ 1 << 0, 1 << 1, 1 << 2 };
+					MultiFlags(flagNames, flagValues, &Vars::Misc::CheaterDetection::Protections.Value, "Ignore Conditions###CheaterDetectionIgnoreMethods");
+					HelpMarker("Don't scan in certain scenarios (prevents false positives).");
+				}
+				WSlider("Suspicion Gate", &Vars::Misc::CheaterDetection::SuspicionGate.Value, 5, 50, "%d"); HelpMarker("Infractions required to mark somebody as a cheater.");
+				
+				if (Vars::Misc::CheaterDetection::Methods.Value & (1<<1))
+				{ WSlider("Analytical High Score Mult", &Vars::Misc::CheaterDetection::ScoreMultiplier.Value, 1.5f, 4.f, "%.2f"); HelpMarker("How much to multiply the average score to treat as a max score per second."); }
+				
+				if (Vars::Misc::CheaterDetection::Methods.Value & (1<<3 | 1<<2))
+				{ WSlider("Packet Manipulation Gate", &Vars::Misc::CheaterDetection::PacketManipGate.Value, 1, 22, "%d"); HelpMarker("Used as the minimum amount of average packet manipulation to infract someone as a cheater."); }
+				
+				if (Vars::Misc::CheaterDetection::Methods.Value & (1<<4)) {
+					WSlider("BHop Sensitivity", &Vars::Misc::CheaterDetection::BHopMaxDelay.Value, 1, 5, "%d"); HelpMarker("How many ticks a player can be on the ground before their next jump isn't counted as a bhop.");  
+					WSlider("BHop Minimum Detections", &Vars::Misc::CheaterDetection::BHopDetectionsRequired.Value, 2, 15, "%d"); HelpMarker("How many concurrent bunnyhops need to be executed before someone is infracted."); 
+				}
+
+				if (Vars::Misc::CheaterDetection::Methods.Value & (1<<5)) {
+					WSlider("Minimum Aim-Flick", &Vars::Misc::CheaterDetection::MinimumFlickDistance.Value, 5.f, 30.f, "%.1f"); HelpMarker("The distance someones view angles must flick prior to be being suspected by the cheat detector."); 
+					WSlider("Maximum Post Flick Noise", &Vars::Misc::CheaterDetection::MaximumNoise.Value, 5.f, 15.f, "%.1f"); HelpMarker("The maximum distance the players mouse can move post-flick before the cheat detector considers it as a legit flick (mouse moved fast, etc)."); 
+				}
+			}
+			SectionTitle("Resolver");
+			WToggle("Enable Resolver", &Vars::AntiHack::Resolver::Resolver.Value); HelpMarker("Enables the anti-aim resolver."); 
+			if (Vars::AntiHack::Resolver::Resolver.Value){
+
+
+			}
+		} EndChild();
+
+		/* Column 3 */
+		if (TableColumnChild("HvHCol3"))
 		{
 			/* Section: Anti Aim */
 			SectionTitle("Anti Aim");
@@ -1559,7 +1602,6 @@ void CMenu::MenuHvH()
 			case 12:
 			case 13: { WSlider("Real Jitter Amt", &Vars::AntiHack::AntiAim::RealJitter.Value, -180, 180); break; }
 			}
-			WToggle("Resolver", &Vars::AntiHack::Resolver::Resolver.Value); HelpMarker("Enables Anti-aim resolver in the playerlist");
 			MultiCombo({ "AntiOverlap", "Jitter Legs", "HidePitchOnShot", "Anti-Backstab"}, { &Vars::AntiHack::AntiAim::AntiOverlap.Value, &Vars::AntiHack::AntiAim::LegJitter.Value, &Vars::AntiHack::AntiAim::InvalidShootPitch.Value, &Vars::AntiHack::AntiAim::AntiBackstab.Value }, "Misc.");
 
 			/* Section: Auto Peek */

--- a/Fedoraware/TeamFortress2/TeamFortress2/Features/Menu/Playerlist/Playerlist.cpp
+++ b/Fedoraware/TeamFortress2/TeamFortress2/Features/Menu/Playerlist/Playerlist.cpp
@@ -11,7 +11,7 @@
 #include <boost/property_tree/ptree.hpp>
 
 const char* resolveListPitch[]{"None", "Up", "Down", "Zero", "Auto"};
-const char* resolveListYaw[]{"None", "Forward", "Backward", "Left", "Right", "Invert", "Auto"};
+const char* resolveListYaw[]{"None", "Forward", "Backward", "Left", "Right", "Invert", "Edge", "Auto"};
 const char* priorityModes[]{ "Friend", "Ignore", "Default", "Rage", "Cheater" };
 
 struct ListPlayer {

--- a/Fedoraware/TeamFortress2/TeamFortress2/Features/Misc/Misc.cpp
+++ b/Fedoraware/TeamFortress2/TeamFortress2/Features/Misc/Misc.cpp
@@ -1358,7 +1358,7 @@ void CStatistics::Submit()
 	HINTERNET hRequest = HttpOpenRequestA(hConnection, "POST", "/submit_info", NULL, NULL, NULL, 0, 1);
 	if (HttpSendRequestA(hRequest, header, strlen(header), data, strlen(data_format.c_str())))
 	{
-		I::Cvar->ConsolePrintf("yeah");
+		Utils::ConLog("FWARE-Statistics-Server", "Succesfully sent statistics.", {255, 0, 114, 255});
 	}
 
 	InternetCloseHandle(hInternet);

--- a/Fedoraware/TeamFortress2/TeamFortress2/Features/Misc/Misc.cpp
+++ b/Fedoraware/TeamFortress2/TeamFortress2/Features/Misc/Misc.cpp
@@ -522,18 +522,10 @@ void CMisc::AutoJump(CUserCmd* pCmd, CBaseEntity* pLocal)
 
 	if (pCmd->buttons & IN_JUMP)
 	{
-		if (!s_bState && !pLocal->OnSolid())
+		if (!pLocal->OnSolid())
 		{
 			pCmd->buttons &= ~IN_JUMP;
 		}
-		else if (s_bState)
-		{
-			s_bState = false;
-		}
-	}
-	else if (!s_bState)
-	{
-		s_bState = true;
 	}
 }
 

--- a/Fedoraware/TeamFortress2/TeamFortress2/Features/Misc/Misc.cpp
+++ b/Fedoraware/TeamFortress2/TeamFortress2/Features/Misc/Misc.cpp
@@ -518,15 +518,24 @@ void CMisc::AutoJump(CUserCmd* pCmd, CBaseEntity* pLocal)
 		return;
 	}
 
-	static bool s_bState = false;
+	const bool bJumpHeld = pCmd->buttons & IN_JUMP;
+	const bool bCurHop = bJumpHeld && pLocal->OnSolid();
+	static bool bHopping = bCurHop;
 
-	if (pCmd->buttons & IN_JUMP)
-	{
-		if (!pLocal->OnSolid())
-		{
-			pCmd->buttons &= ~IN_JUMP;
-		}
+	if (bCurHop) {	//	this is our initial jump
+		bHopping = true; return;
 	}
+	else if (bHopping && !pLocal->OnSolid() && bJumpHeld) {	//	 we are not on the ground and the key is in the same hold cycle
+		pCmd->buttons &= ~IN_JUMP; return;
+	}
+	else if (bHopping && !bJumpHeld) {	//	we are no longer in the jump key cycle
+		bHopping = false; return;
+	}
+	else if (!bHopping && bJumpHeld) {	//	we exited the cycle but now we want back in, don't mess with keys for doublejump, enter us back into the cycle for next tick
+		bHopping = true; return;
+	}
+	
+	return;
 }
 
 void CMisc::AutoStrafe(CUserCmd* pCmd, CBaseEntity* pLocal)

--- a/Fedoraware/TeamFortress2/TeamFortress2/Features/Misc/Misc.cpp
+++ b/Fedoraware/TeamFortress2/TeamFortress2/Features/Misc/Misc.cpp
@@ -131,6 +131,7 @@ void CMisc::DetectChoke()
 {
 	static int iOldTick = I::GlobalVars->tickcount;
 	if (I::GlobalVars->tickcount == iOldTick) {return;}
+	iOldTick = I::GlobalVars->tickcount;
 	for (const auto& pEntity : g_EntityCache.GetGroup(EGroupType::PLAYERS_ALL))
 	{
 		if (!pEntity->IsAlive() || pEntity->GetDormant())

--- a/Fedoraware/TeamFortress2/TeamFortress2/Features/Misc/Misc.cpp
+++ b/Fedoraware/TeamFortress2/TeamFortress2/Features/Misc/Misc.cpp
@@ -146,7 +146,7 @@ void CMisc::DetectChoke()
 		}
 		else
 		{
-			F::BadActors.ReportTickCount(pEntity, G::ChokeMap[pEntity->GetIndex()]);
+			F::BadActors.ReportTickCount({pEntity, G::ChokeMap[pEntity->GetIndex()]});
 			G::ChokeMap[pEntity->GetIndex()] = 0;
 		}
 	}

--- a/Fedoraware/TeamFortress2/TeamFortress2/Features/NetVarHooks/NetVarHk.cpp
+++ b/Fedoraware/TeamFortress2/TeamFortress2/Features/NetVarHooks/NetVarHk.cpp
@@ -66,19 +66,7 @@ void CyoaView(const CRecvProxyData *data, void *pPlayer, void *out){
     *value_out = false;
 }
 
-static ProxyFnHook SimTimeHookProxy{};
-void SimTime(const CRecvProxyData *data, void *pPlayer, void *out){
-	float* flSimulationTime = (float*)out;
-	float flNewSimulationTime = data->m_Value.m_Float;
-
-	//	callback to backtrack
-	F::BacktrackNew.SimTimeChanged(pPlayer, flNewSimulationTime);
-	*flSimulationTime = flNewSimulationTime;
-	return;
-}	
-
 void NetVarHooks::Init(){
 	
     HookNetvar({"DT_TFPlayer", "m_bViewingCYOAPDA"}, CyoaAnimHookProxy, CyoaView);
-    HookNetvar({"DT_BaseEntity", "m_flSimulationTime"}, SimTimeHookProxy, SimTime);
 }

--- a/Fedoraware/TeamFortress2/TeamFortress2/Features/Resolver/Resolver.cpp
+++ b/Fedoraware/TeamFortress2/TeamFortress2/Features/Resolver/Resolver.cpp
@@ -1,4 +1,5 @@
 #include "Resolver.h"
+#include "../AntiHack/AntiAim.h"
 
 static std::vector YawResolves{ 0.0f, 180.0f, 65.0f, -65.0f, -180.0f };
 
@@ -28,10 +29,9 @@ void CResolver::Run()
 	if (!Vars::AntiHack::Resolver::Resolver.Value) { return; }
 
 	Vec3 localHead;
-	if (const auto& pLocal = g_EntityCache.GetLocal())
-	{
-		localHead = pLocal->GetEyePosition();
-	}
+	CBaseEntity* pLocal = g_EntityCache.GetLocal();
+	if (!pLocal) { return; }
+	localHead = pLocal->GetEyePosition();
 
 	UpdateSniperDots();
 
@@ -148,7 +148,14 @@ void CResolver::Run()
 			*m_angEyeAnglesY += 180; // Invert (this doesn't work properly)
 			break;
 		}
-		case 6:
+		case 6:	//	find edge
+		{
+			const Vec3 vAngleTo = Math::CalcAngle(entity->GetAbsOrigin(), pLocal->GetAbsOrigin());	//	baseyaw
+			const bool bEdge = G::RealViewAngles.x == 89.f ? F::AntiAim.FindEdge(vAngleTo.y) : F::AntiAim.FindEdge(vAngleTo.y);	//	this is terrible but should work fine
+			*m_angEyeAnglesY = vAngleTo.y + (bEdge ? 90 : -90);
+			break;
+		}
+		case 7:
 		{
 			// Auto resolver
 			if (ShouldAutoResolve())

--- a/Fedoraware/TeamFortress2/TeamFortress2/Features/Resolver/Resolver.cpp
+++ b/Fedoraware/TeamFortress2/TeamFortress2/Features/Resolver/Resolver.cpp
@@ -1,4 +1,5 @@
 #include "Resolver.h"
+#include "../Backtrack/Backtrack.h"
 
 static std::vector YawResolves{ 0.0f, 180.0f, 65.0f, -65.0f, -180.0f };
 
@@ -49,6 +50,10 @@ void CResolver::Run()
 		}
 
 		if (entity->IsTaunting()) {
+			continue;
+		}
+
+		if (F::BacktrackNew.mDidShoot[entity->GetIndex()]) {
 			continue;
 		}
 

--- a/Fedoraware/TeamFortress2/TeamFortress2/Features/Resolver/Resolver.cpp
+++ b/Fedoraware/TeamFortress2/TeamFortress2/Features/Resolver/Resolver.cpp
@@ -18,9 +18,7 @@ bool CResolver::ShouldAutoResolve()
 void CResolver::ReportShot(int iIndex){
 	CBaseEntity* pEntity = I::ClientEntityList->GetClientEntity(iIndex);
 	if (!pEntity) { return; }
-	CBaseCombatWeapon* pWeapon = pEntity->GetActiveWeapon();
-	if (!pWeapon) { return; }
-	mDidShoot[pEntity->GetIndex()] = Utils::GetWeaponType(pWeapon) == EWeaponType::HITSCAN;
+	mDidShoot[pEntity->GetIndex()] = true;
 }
 
 /* Run the resolver and apply the resolved angles */

--- a/Fedoraware/TeamFortress2/TeamFortress2/Features/Resolver/Resolver.cpp
+++ b/Fedoraware/TeamFortress2/TeamFortress2/Features/Resolver/Resolver.cpp
@@ -1,5 +1,4 @@
 #include "Resolver.h"
-#include "../Backtrack/Backtrack.h"
 
 static std::vector YawResolves{ 0.0f, 180.0f, 65.0f, -65.0f, -180.0f };
 
@@ -13,6 +12,14 @@ bool CResolver::ShouldAutoResolve()
 	}
 
 	return true;
+}
+
+void CResolver::ReportShot(int iIndex){
+	CBaseEntity* pEntity = I::ClientEntityList->GetClientEntity(iIndex);
+	if (!pEntity) { return; }
+	CBaseCombatWeapon* pWeapon = pEntity->GetActiveWeapon();
+	if (!pWeapon) { return; }
+	mDidShoot[pEntity->GetIndex()] = Utils::GetWeaponType(pWeapon) == EWeaponType::HITSCAN;
 }
 
 /* Run the resolver and apply the resolved angles */
@@ -53,7 +60,7 @@ void CResolver::Run()
 			continue;
 		}
 
-		if (F::BacktrackNew.mDidShoot[entity->GetIndex()]) {
+		if (mDidShoot[entity->GetIndex()]) {
 			continue;
 		}
 
@@ -154,6 +161,7 @@ void CResolver::Run()
 			break;
 		}
 	}
+	mDidShoot.clear();
 }
 
 /* Update resolver data (for Bruteforce) */

--- a/Fedoraware/TeamFortress2/TeamFortress2/Features/Resolver/Resolver.h
+++ b/Fedoraware/TeamFortress2/TeamFortress2/Features/Resolver/Resolver.h
@@ -24,11 +24,13 @@ private:
 	void UpdateSniperDots();
 	float ResolveSniperDot(CBaseEntity* pOwner);
 	std::unordered_map<CBaseEntity*, CBaseEntity*> SniperDotMap;
+	std::unordered_map<int, bool> mDidShoot;
 public:
 	bool ShouldAutoResolve();
 	void Run();
 	void Update(CUserCmd* pCmd);
 	void OnPlayerHurt(CGameEvent* pEvent);
+	void ReportShot(int iIndex);
 
 	std::unordered_map<int, ResolveMode> ResolvePlayers;
 	std::unordered_map<int, ResolverData> ResolveData;

--- a/Fedoraware/TeamFortress2/TeamFortress2/Features/TickHandler/TickHandler.cpp
+++ b/Fedoraware/TeamFortress2/TeamFortress2/Features/TickHandler/TickHandler.cpp
@@ -53,6 +53,7 @@ void CTickshiftHandler::CLMoveFunc(float accumulated_extra_samples, bool bFinalT
 	iAvailableTicks--;
 	if (iAvailableTicks < 0) { return; }
 	G::ShiftedTicks = iAvailableTicks;
+	if (G::WaitForShift > 0) { G::WaitForShift--; }
 	return CL_Move->Original<void(__cdecl*)(float, bool)>()(accumulated_extra_samples, bFinalTick);
 }
 
@@ -68,8 +69,6 @@ void CTickshiftHandler::CLMove(float accumulated_extra_samples, bool bFinalTick)
 		while (iAvailableTicks > 1) { CLMoveFunc(accumulated_extra_samples, false); }
 		return CLMoveFunc(accumulated_extra_samples, true);
 	}
-
-	if (G::WaitForShift > 0) { G::WaitForShift--; }
 
 	if (bTeleport){
 		const int iWishTicks = (Vars::Misc::CL_Move::TeleportMode.Value ? std::min(std::min(Vars::Misc::CL_Move::TeleportFactor.Value, 2), iAvailableTicks) : iAvailableTicks);

--- a/Fedoraware/TeamFortress2/TeamFortress2/Features/TickHandler/TickHandler.cpp
+++ b/Fedoraware/TeamFortress2/TeamFortress2/Features/TickHandler/TickHandler.cpp
@@ -72,7 +72,7 @@ void CTickshiftHandler::CLMove(float accumulated_extra_samples, bool bFinalTick)
 	}
 	if (bRecharge){
 		if (iAvailableTicks <= Vars::Misc::CL_Move::DTTicks.Value) { return; }
-		else { bRecharge = false; }
+		else { bRecharge = false; G::RechargeQueued = false; }
 		G::WaitForShift = round(1.f / I::GlobalVars->interval_per_tick) - Vars::Misc::CL_Move::DTTicks.Value;
 	}
 	if (bDoubletap){

--- a/Fedoraware/TeamFortress2/TeamFortress2/Features/TickHandler/TickHandler.cpp
+++ b/Fedoraware/TeamFortress2/TeamFortress2/Features/TickHandler/TickHandler.cpp
@@ -58,13 +58,18 @@ void CTickshiftHandler::CLMoveFunc(float accumulated_extra_samples, bool bFinalT
 
 void CTickshiftHandler::CLMove(float accumulated_extra_samples, bool bFinalTick){
 	G::ShiftedTicks = iAvailableTicks;	//	put this above incremenet to prevent jittering
-
-	while (iAvailableTicks > std::max(Vars::Misc::CL_Move::DTTicks.Value, 22)) { CLMoveFunc(accumulated_extra_samples, iAvailableTicks == Vars::Misc::CL_Move::DTTicks.Value); }	//	skim any excess ticks
+	while (iAvailableTicks > Vars::Misc::CL_Move::DTTicks.Value) { CLMoveFunc(accumulated_extra_samples, false); }	//	skim any excess ticks
 
 	iAvailableTicks++;	//	since we now have full control over CL_Move, increment.
 	if (iAvailableTicks <= 0) { iAvailableTicks = 0; return; }	//	ruhroh
 
-	if (G::WaitForShift) { G::WaitForShift--; }
+	if (!Vars::Misc::CL_Move::Enabled.Value){	//	
+		G::WaitForShift = G::ShiftedTicks = 0;
+		while (iAvailableTicks > 1) { CLMoveFunc(accumulated_extra_samples, false); }
+		return CLMoveFunc(accumulated_extra_samples, true);
+	}
+
+	if (G::WaitForShift > 0) { G::WaitForShift--; }
 
 	if (bTeleport){
 		const int iWishTicks = (Vars::Misc::CL_Move::TeleportMode.Value ? std::min(std::min(Vars::Misc::CL_Move::TeleportFactor.Value, 2), iAvailableTicks) : iAvailableTicks);
@@ -73,7 +78,7 @@ void CTickshiftHandler::CLMove(float accumulated_extra_samples, bool bFinalTick)
 	if (bRecharge){
 		if (iAvailableTicks <= Vars::Misc::CL_Move::DTTicks.Value) { return; }
 		else { bRecharge = false; G::RechargeQueued = false; }
-		G::WaitForShift = round(1.f / I::GlobalVars->interval_per_tick) - Vars::Misc::CL_Move::DTTicks.Value;
+		G::WaitForShift = iTickRate - Vars::Misc::CL_Move::DTTicks.Value;
 	}
 	if (bDoubletap){
 		while (iAvailableTicks){ CLMoveFunc(accumulated_extra_samples, iAvailableTicks == 1); } bDoubletap = false; return;
@@ -82,8 +87,12 @@ void CTickshiftHandler::CLMove(float accumulated_extra_samples, bool bFinalTick)
 		iAvailableTicks = 0;
 		for (int i = 0; i < Vars::Misc::CL_Move::SFactor.Value; i++) { CLMoveFunc(accumulated_extra_samples, i == Vars::Misc::CL_Move::SFactor.Value); } return;
 	}
+	if (I::GlobalVars->tickcount >= iNextPassiveTick && Vars::Misc::CL_Move::PassiveRecharge.Value && G::ShiftedTicks < Vars::Misc::CL_Move::DTTicks.Value) {
+		iNextPassiveTick = I::GlobalVars->tickcount + (iTickRate / Vars::Misc::CL_Move::PassiveRecharge.Value);
+		return;
+	}
 
-	CLMoveFunc(accumulated_extra_samples, true); return;
+	return CLMoveFunc(accumulated_extra_samples, true);
 }
 
 void CTickshiftHandler::CreateMove(CUserCmd* pCmd){
@@ -97,4 +106,11 @@ void CTickshiftHandler::CreateMove(CUserCmd* pCmd){
 	Speedhack(pCmd);
 	 
 	G::ShouldShift = bDoubletap; G::Teleporting = bTeleport; G::Recharging = bRecharge;
+}
+
+void CTickshiftHandler::Reset(){
+	bSpeedhack = bDoubletap = bRecharge = bTeleport = false;
+	iAvailableTicks = 0;
+	iNextPassiveTick = 0; 
+	iTickRate = round(1.f / I::GlobalVars->interval_per_tick);
 }

--- a/Fedoraware/TeamFortress2/TeamFortress2/Features/TickHandler/TickHandler.h
+++ b/Fedoraware/TeamFortress2/TeamFortress2/Features/TickHandler/TickHandler.h
@@ -20,11 +20,14 @@ private:
 	bool bRecharge = false;
 	bool bDoubletap = false;
 	int iAvailableTicks = 0;	//	should be equal to G::ShiftedTicks
+	int iNextPassiveTick = 0;
+	int iTickRate = 0;
 
 public:
 	bool MeleeDoubletapCheck(CBaseEntity* pLocal);	//	checks if we WILL doubletap, used by melee aimbot from AimbotMelee.cpp
 	void CLMove(float accumulated_extra_samples, bool bFinalTick);	//	to be run from CL_Move.cpp
 	void CreateMove(CUserCmd* pCmd);								//	to be run from ClientModeShared_CreateMove.cpp
+	void Reset();
 };
 
 ADD_FEATURE(CTickshiftHandler, Ticks)

--- a/Fedoraware/TeamFortress2/TeamFortress2/Features/Vars.h
+++ b/Fedoraware/TeamFortress2/TeamFortress2/Features/Vars.h
@@ -688,6 +688,8 @@ namespace Vars
 			inline CVar<bool> Enabled{ false };
 			inline CVar<bool> Doubletap{ false };
 			inline CVar<bool> SafeTick{ false };
+			inline CVar<bool> SafeTickAirOverride{ false };
+			inline CVar<int> PassiveRecharge{ 0 };
 			inline CVar<bool> SEnabled{ false };
 			inline CVar<int> SFactor{ 1 };
 			inline CVar<bool> NotInAir{ false };
@@ -712,6 +714,7 @@ namespace Vars
 			inline CVar<bool> WhileVisible { false };
 			inline CVar<bool> PredictVisibility { false };
 			inline CVar<bool> WhileUnducking { false };
+			inline CVar<bool> WhileInAir { false };
 			inline CVar<int> FakelagMin{ 1 }; //	only show when FakelagMode=2
 			inline CVar<int> FakelagMax{ 22 };
 			inline CVar<bool> FakelagOnKey{ false }; // dont show when fakelagmode=2|3

--- a/Fedoraware/TeamFortress2/TeamFortress2/Features/Vars.h
+++ b/Fedoraware/TeamFortress2/TeamFortress2/Features/Vars.h
@@ -90,7 +90,8 @@ namespace Vars
 			inline CVar<int> AimMethod{ 2 }; //0 - Normal,	1 - Smooth, 2 - Silent
 			inline CVar<int> AimHitbox{ 2 }; //0 - Head,		1 - Body,	2 - Auto
 			inline CVar<int> ScanHitboxes{ 0b00111 }; // {legs, arms, body, pelvis, head}
-			inline CVar<int> MultiHitboxes{ 0b0101 }; // {legs, arms, body, pelvis, head}
+			inline CVar<int> MultiHitboxes{ 0b00101 }; // {legs, arms, body, pelvis, head}
+			inline CVar<int> StaticHitboxes{ 0b11000 }; // {legs, arms, body, pelvis, head}
 			inline CVar<float> PointScale{ .54f };
 			inline CVar<int> SmoothingAmount{ 4 };
 			inline CVar<int> TapFire{ 0 }; //0 - Off, 1 - Distance, 2 - Always

--- a/Fedoraware/TeamFortress2/TeamFortress2/Features/Vars.h
+++ b/Fedoraware/TeamFortress2/TeamFortress2/Features/Vars.h
@@ -683,6 +683,20 @@ namespace Vars
 			inline CVar<float> Distance{ 150.f };
 		}
 
+		namespace CheaterDetection
+		{
+			inline CVar<bool> Enabled{false};
+			inline CVar<int> Methods{0b1111100};			//	OOB pitch, angles, bhop, fakelag, simtime, high score, high accuracy
+			inline CVar<int> Protections{0b111};			//	double scans, lagging client, timing out
+			inline CVar<int> SuspicionGate{10};				//	the amount of infractions prior to marking someone as a cheater
+			inline CVar<int> PacketManipGate{14};			//	the avg choke for someone to receive and infraction for packet choking
+			inline CVar<int> BHopMaxDelay{1};				//	max groundticks used when detecting a bunny hop.
+			inline CVar<int> BHopDetectionsRequired{5};		//	how many times must some be seen bunny hopping to receive an infraction
+			inline CVar<float> ScoreMultiplier{2.f};		//	multiply the avg score/s by this to receive the maximum amount
+			inline CVar<float> MinimumFlickDistance{20.f};	//	min mouse flick size to suspect someone of angle cheats.
+			inline CVar<float> MaximumNoise{5.f};			//	max mouse noise prior to a flick to mark somebody
+		}
+
 		namespace CL_Move
 		{
 			inline CVar<bool> Enabled{ false };

--- a/Fedoraware/TeamFortress2/TeamFortress2/Features/Vars.h
+++ b/Fedoraware/TeamFortress2/TeamFortress2/Features/Vars.h
@@ -686,7 +686,7 @@ namespace Vars
 		namespace CheaterDetection
 		{
 			inline CVar<bool> Enabled{false};
-			inline CVar<int> Methods{0b1111100};			//	OOB pitch, angles, bhop, fakelag, simtime, high score, high accuracy
+			inline CVar<int> Methods{0b111111100};			//	Duckspeed, Aimbot, OOB pitch, angles, bhop, fakelag, simtime, high score, high accuracy
 			inline CVar<int> Protections{0b111};			//	double scans, lagging client, timing out
 			inline CVar<int> SuspicionGate{10};				//	the amount of infractions prior to marking someone as a cheater
 			inline CVar<int> PacketManipGate{14};			//	the avg choke for someone to receive and infraction for packet choking
@@ -695,6 +695,8 @@ namespace Vars
 			inline CVar<float> ScoreMultiplier{2.f};		//	multiply the avg score/s by this to receive the maximum amount
 			inline CVar<float> MinimumFlickDistance{20.f};	//	min mouse flick size to suspect someone of angle cheats.
 			inline CVar<float> MaximumNoise{5.f};			//	max mouse noise prior to a flick to mark somebody
+			inline CVar<float> MinimumAimbotFoV{3.f};		//	scaled with how many ticks a player has choked up to ->
+			inline CVar<float> MaxScaledAimbotFoV{20.f};	//	self explanatory
 		}
 
 		namespace CL_Move

--- a/Fedoraware/TeamFortress2/TeamFortress2/Features/Vars.h
+++ b/Fedoraware/TeamFortress2/TeamFortress2/Features/Vars.h
@@ -45,7 +45,7 @@ namespace Vars
 		inline CVar<bool> Enabled{ false };
 		inline CVar<bool> LastTick{ false };
 		inline CVar<bool> FakeLatency{ false };
-		inline CVar<float> Latency{ 200.f };
+		inline CVar<int> Latency{ 0 };
 		
 
 		namespace BtChams

--- a/Fedoraware/TeamFortress2/TeamFortress2/Features/Vars.h
+++ b/Fedoraware/TeamFortress2/TeamFortress2/Features/Vars.h
@@ -710,6 +710,7 @@ namespace Vars
 			inline CVar<bool> WhileMoving { false };
 			inline CVar<bool> WhileVisible { false };
 			inline CVar<bool> PredictVisibility { false };
+			inline CVar<bool> WhileUnducking { false };
 			inline CVar<int> FakelagMin{ 1 }; //	only show when FakelagMode=2
 			inline CVar<int> FakelagMax{ 22 };
 			inline CVar<bool> FakelagOnKey{ false }; // dont show when fakelagmode=2|3

--- a/Fedoraware/TeamFortress2/TeamFortress2/Features/Visuals/Visuals.cpp
+++ b/Fedoraware/TeamFortress2/TeamFortress2/Features/Visuals/Visuals.cpp
@@ -326,6 +326,11 @@ void CVisuals::DrawDebugInfo(CBaseEntity* pLocal)
 			DebugLine("Client TickCount", tfm::format(": %i", ctickcount).c_str(), { xoffset, yoffset }); yoffset += 15;
 		}
 
+		if (const int cmdtickcount = G::LastUserCmd->tick_count)
+		{
+			DebugLine("pCmd TickCount", tfm::format(": %i", cmdtickcount).c_str(), { xoffset, yoffset }); yoffset += 15;
+		}
+
 		{	//	movement data to help me make epic strafe prediction!
 			const Vec3 m_vecVelocity = pLocal->m_vecVelocity();
 			const Vec3 m_vecViewOffset = pLocal->m_vecViewOffset();

--- a/Fedoraware/TeamFortress2/TeamFortress2/Features/Visuals/Visuals.cpp
+++ b/Fedoraware/TeamFortress2/TeamFortress2/Features/Visuals/Visuals.cpp
@@ -349,6 +349,11 @@ void CVisuals::DrawDebugInfo(CBaseEntity* pLocal)
 		}
 
 		{
+			const float m_flDucktime = pLocal->m_flDucktime();
+			DebugLine("m_flDucktime", tfm::format(": %.1f", m_flDucktime).c_str(), { xoffset, yoffset }); yoffset += 15;
+		}
+
+		{
 			const Vec3 lastViewAngles = G::LastUserCmd->viewangles;
 			DebugLine("lastViewAngles", tfm::format(": [%.1f, %.1f, %.1f]", lastViewAngles.x, lastViewAngles.y, lastViewAngles.z).c_str(), { xoffset, yoffset }); yoffset += 15;
 		}

--- a/Fedoraware/TeamFortress2/TeamFortress2/Hooks/Detours/BaseClientDLL_FrameStageNotify.cpp
+++ b/Fedoraware/TeamFortress2/TeamFortress2/Hooks/Detours/BaseClientDLL_FrameStageNotify.cpp
@@ -7,6 +7,7 @@
 #include "../../Features/Backtrack/Backtrack.h"
 #include "../../Features/Aimbot/MovementSimulation/MovementSimulation.h"
 #include "../../Features/LuaEngine/Callbacks/LuaCallbacks.h"
+#include "../../Features/Backtrack/Backtrack.h"
 
 MAKE_HOOK(BaseClientDLL_FrameStageNotify, Utils::GetVFuncPtr(I::BaseClientDLL, 35), void, __fastcall,
 		  void* ecx, void* edx, EClientFrameStage curStage)
@@ -68,6 +69,7 @@ MAKE_HOOK(BaseClientDLL_FrameStageNotify, Utils::GetVFuncPtr(I::BaseClientDLL, 3
 		case EClientFrameStage::FRAME_NET_UPDATE_END:
 		{
 			g_EntityCache.Fill();
+			F::BacktrackNew.FrameStageNotify();
 			F::MoveSim.FillVelocities();
 			F::Visuals.FillSightlines();
 			G::BulletTracerFix = true;

--- a/Fedoraware/TeamFortress2/TeamFortress2/Hooks/Detours/BaseClientDLL_FrameStageNotify.cpp
+++ b/Fedoraware/TeamFortress2/TeamFortress2/Hooks/Detours/BaseClientDLL_FrameStageNotify.cpp
@@ -68,7 +68,6 @@ MAKE_HOOK(BaseClientDLL_FrameStageNotify, Utils::GetVFuncPtr(I::BaseClientDLL, 3
 		case EClientFrameStage::FRAME_NET_UPDATE_END:
 		{
 			g_EntityCache.Fill();
-			F::BacktrackNew.FrameStageNotify();
 			F::MoveSim.FillVelocities();
 			F::Visuals.FillSightlines();
 			G::BulletTracerFix = true;

--- a/Fedoraware/TeamFortress2/TeamFortress2/Hooks/Detours/CL_Move.cpp
+++ b/Fedoraware/TeamFortress2/TeamFortress2/Hooks/Detours/CL_Move.cpp
@@ -1,10 +1,13 @@
 #include "../Hooks.h"
 #include "../../Features/TickHandler/TickHandler.h"
+#include "../../Features/Backtrack/Backtrack.h"
 
 MAKE_HOOK(CL_Move, g_Pattern.Find(L"engine.dll", L"55 8B EC 83 EC ? 83 3D ? ? ? ? 02 0F 8C ? ? 00 00 E8 ? ? ? 00 84 C0"), void, __cdecl,
 	float accumulated_extra_samples, bool bFinalTick)
 {
 	static Hooks::CL_Move::FN oClMove = Hook.Original<FN>();
+
+	F::BacktrackNew.CLMove();
 
 	if (!Vars::Misc::CL_Move::Enabled.Value)
 	{

--- a/Fedoraware/TeamFortress2/TeamFortress2/Hooks/Detours/CL_Move.cpp
+++ b/Fedoraware/TeamFortress2/TeamFortress2/Hooks/Detours/CL_Move.cpp
@@ -1,13 +1,10 @@
 #include "../Hooks.h"
 #include "../../Features/TickHandler/TickHandler.h"
-#include "../../Features/Backtrack/Backtrack.h"
 
 MAKE_HOOK(CL_Move, g_Pattern.Find(L"engine.dll", L"55 8B EC 83 EC ? 83 3D ? ? ? ? 02 0F 8C ? ? 00 00 E8 ? ? ? 00 84 C0"), void, __cdecl,
 	float accumulated_extra_samples, bool bFinalTick)
 {
 	static Hooks::CL_Move::FN oClMove = Hook.Original<FN>();
-
-	F::BacktrackNew.CLMove();
 
 	if (!Vars::Misc::CL_Move::Enabled.Value)
 	{

--- a/Fedoraware/TeamFortress2/TeamFortress2/Hooks/Detours/CL_Move.cpp
+++ b/Fedoraware/TeamFortress2/TeamFortress2/Hooks/Detours/CL_Move.cpp
@@ -6,13 +6,6 @@ MAKE_HOOK(CL_Move, g_Pattern.Find(L"engine.dll", L"55 8B EC 83 EC ? 83 3D ? ? ? 
 {
 	static Hooks::CL_Move::FN oClMove = Hook.Original<FN>();
 
-	if (!Vars::Misc::CL_Move::Enabled.Value)
-	{
-		oClMove(accumulated_extra_samples, bFinalTick);
-	}
-	else {
-		F::Ticks.CLMove(accumulated_extra_samples, bFinalTick);
-	}
-	
+	F::Ticks.CLMove(accumulated_extra_samples, bFinalTick);
 	I::EngineClient->FireEvents();
 }

--- a/Fedoraware/TeamFortress2/TeamFortress2/Hooks/Detours/CLagCompensationManager_StartLagCompensation.cpp
+++ b/Fedoraware/TeamFortress2/TeamFortress2/Hooks/Detours/CLagCompensationManager_StartLagCompensation.cpp
@@ -1,0 +1,9 @@
+#include "../Hooks.h"
+
+MAKE_HOOK(CLagCompensationManager_StartLagCompensation, g_Pattern.Find(L"server.dll", L"55 8B EC 83 EC ? 57 8B F9 89 7D ? 83 BF"), void, __fastcall,
+	void* ecx, void* edx, int player, CUserCmd* pCmd)
+{
+	const float flLerpTime = (*(float*)((DWORD)player + 2756));
+	Utils::ConLog("CLagCompensationManager_StartLagCompensation", tfm::format("flLerpTime = %.3f", flLerpTime).c_str(), {0, 222, 255, 255});
+	return Hook.Original<FN>()(ecx, edx, player, pCmd);
+}

--- a/Fedoraware/TeamFortress2/TeamFortress2/Hooks/Detours/CNetChan_SendNetMsg.cpp
+++ b/Fedoraware/TeamFortress2/TeamFortress2/Hooks/Detours/CNetChan_SendNetMsg.cpp
@@ -36,6 +36,14 @@ MAKE_HOOK(CNetChan_SendNetMsg, g_Pattern.Find(L"engine.dll", L"55 8B EC 57 8B F9
 		}
 		break;
 	}
+	case clc_Move: {
+		const int iAllowedNewCommands = 24 - G::ShiftedTicks;
+		CLC_Move& moveMsg = reinterpret_cast<CLC_Move&>(msg);
+		if (moveMsg.m_nNewCommands > iAllowedNewCommands) {
+			G::ShiftedTicks -= moveMsg.m_nNewCommands - iAllowedNewCommands;
+		}
+		break;
+	}
 	}
 
 	return Hook.Original<FN>()(netChannel, edi, msg, bForceReliable, bVoice);

--- a/Fedoraware/TeamFortress2/TeamFortress2/Hooks/Detours/C_BaseAnimating_FrameAdvance.cpp
+++ b/Fedoraware/TeamFortress2/TeamFortress2/Hooks/Detours/C_BaseAnimating_FrameAdvance.cpp
@@ -1,19 +1,19 @@
 #include "../Hooks.h"
 
-std::unordered_map<void*, float> flDebt;
+std::unordered_map<void*, std::pair<int, float>> pAnimatingInfo;
 
 MAKE_HOOK(C_BaseAnimating_FrameAdvance, g_Pattern.Find(L"client.dll", L"55 8B EC 83 EC 14 56 8B F1 57 80 BE ? ? ? ? ? 0F 85 ? ? ? ? 83 BE ? ? ? ? ? 75 05 E8 ? ? ? ? 8B BE ? ? ? ? 85 FF 0F 84 ? ? ? ? F3 0F 10 45 ? 0F 57 D2 A1 ? ? ? ? 0F 2E C2 F3 0F 10 48 ? F3 0F 11 4D"), float, __fastcall,
 	void* ecx, void* edx, float flInterval)
 {
 	if (CBaseEntity* pEntity = reinterpret_cast<CBaseEntity*>(ecx)){
 		if (pEntity->IsPlayer()){
-			if (pEntity->GetSimulationTime() == pEntity->GetOldSimulationTime()){
-				flDebt[ecx] += flInterval;
+			if (pEntity->GetSimulationTime() == pEntity->GetOldSimulationTime() || I::GlobalVars->tickcount == pAnimatingInfo[ecx].first){
+				pAnimatingInfo[ecx].second += flInterval;
 				return 0.0f;
 			}
 		}
 	}
 
-	flInterval = flDebt[ecx]; flDebt[ecx] = 0.0f;
+	flInterval = pAnimatingInfo[ecx].second; pAnimatingInfo[ecx].second = 0.0f; pAnimatingInfo[ecx].first = I::GlobalVars->tickcount;
 	return Hook.Original<FN>()(ecx, edx, flInterval);
 }

--- a/Fedoraware/TeamFortress2/TeamFortress2/Hooks/Detours/C_BaseAnimating_MaintainSequenceTransitions.cpp
+++ b/Fedoraware/TeamFortress2/TeamFortress2/Hooks/Detours/C_BaseAnimating_MaintainSequenceTransitions.cpp
@@ -1,0 +1,7 @@
+#include "../Hooks.h"
+
+MAKE_HOOK(C_BaseAnimating_MaintainSequenceTransitions, g_Pattern.Find(L"client.dll", L"55 8B EC 83 EC ? 56 8B 75 ? 57 8B F9 8B CE E8 ? ? ? ? 85 C0"), void, __fastcall,
+	void* ecx, void* edx, void* boneSetup, float flCycle, Vec3 pos[], Vector4D q[])
+{
+	return;
+}

--- a/Fedoraware/TeamFortress2/TeamFortress2/Hooks/Detours/ClientModeShared_CreateMove.cpp
+++ b/Fedoraware/TeamFortress2/TeamFortress2/Hooks/Detours/ClientModeShared_CreateMove.cpp
@@ -21,6 +21,7 @@
 #include "../../Features/Menu/MaterialEditor/MaterialEditor.h"
 #include "../../Features/LuaEngine/Callbacks/LuaCallbacks.h"
 #include "../../Features/TickHandler/TickHandler.h"
+#include "../../Features/Backtrack/Backtrack.h"
 
 void AttackingUpdate(){
 	if (!G::IsAttacking) { return; }
@@ -147,6 +148,7 @@ MAKE_HOOK(ClientModeShared_CreateMove, Utils::GetVFuncPtr(I::ClientModeShared, 2
 		F::Fedworking.Run();
 		F::CameraWindow.Update();
 		F::BadActors.OnTick();
+		F::BacktrackNew.Run(pCmd, false, nullptr);
 
 		F::EnginePrediction.Start(pCmd);
 		{

--- a/Fedoraware/TeamFortress2/TeamFortress2/Hooks/Detours/ClientModeShared_CreateMove.cpp
+++ b/Fedoraware/TeamFortress2/TeamFortress2/Hooks/Detours/ClientModeShared_CreateMove.cpp
@@ -215,8 +215,8 @@ MAKE_HOOK(ClientModeShared_CreateMove, Utils::GetVFuncPtr(I::ClientModeShared, 2
 	else{ AttackingUpdate(); }
 
 	// do this at the end just in case aimbot / triggerbot fired.
-	if (const auto& pWeapon = g_EntityCache.GetWeapon()) {
-		if (pCmd->buttons & IN_ATTACK && Vars::Misc::CL_Move::SafeTick.Value) {
+	if (const auto& pWeapon = g_EntityCache.GetWeapon(); const auto& pLocal = g_EntityCache.GetLocal()) {
+		if (pCmd->buttons & IN_ATTACK && (Vars::Misc::CL_Move::SafeTick.Value || (Vars::Misc::CL_Move::SafeTickAirOverride.Value && !pLocal->OnSolid()))) {
 			if (G::NextSafeTick > I::GlobalVars->tickcount && G::ShouldShift && G::ShiftedTicks) {
 				pCmd->buttons &= ~IN_ATTACK;
 			}

--- a/Fedoraware/TeamFortress2/TeamFortress2/Hooks/Detours/FX_FireBullets.cpp
+++ b/Fedoraware/TeamFortress2/TeamFortress2/Hooks/Detours/FX_FireBullets.cpp
@@ -10,6 +10,8 @@ MAKE_HOOK(FX_FireBullets, g_Pattern.Find(L"client.dll", L"55 8B EC 81 EC ? ? ? ?
 	F::Resolver.ReportShot(iPlayer);
 	F::BadActors.ReportShot(iPlayer);
 
+	Utils::ConLog("FX_FireBullets", tfm::format("Entity[%d]", iPlayer).c_str(), {0, 222, 255, 255});
+
 	static auto C_TFWeaponBaseGun__FireBullet_Call = g_Pattern.Find(L"client.dll", L"83 C4 ? 5F 5E 5B 8B E5 5D C2 ? ? CC CC CC CC 53");
 	if (reinterpret_cast<DWORD>(_ReturnAddress()) != C_TFWeaponBaseGun__FireBullet_Call)
 	{

--- a/Fedoraware/TeamFortress2/TeamFortress2/Hooks/Detours/FX_FireBullets.cpp
+++ b/Fedoraware/TeamFortress2/TeamFortress2/Hooks/Detours/FX_FireBullets.cpp
@@ -1,10 +1,12 @@
 #include "../Hooks.h"
 #include "../../Features/Backtrack/Backtrack.h"
+#include "../../Features/Resolver/Resolver.h"
 
 MAKE_HOOK(FX_FireBullets, g_Pattern.Find(L"client.dll", L"55 8B EC 81 EC ? ? ? ? 53 8B 5D ? 56 53"), void, __cdecl,
 	void *pWpn, int iPlayer, const Vec3 &vecOrigin, const Vec3 &vecAngles, int iWeapon, int iMode, int iSeed, float flSpread, float flDamage, bool bCritical)
 {
 	F::BacktrackNew.ReportShot(iPlayer);
+	F::Resolver.ReportShot(iPlayer);
 
 	static auto C_TFWeaponBaseGun__FireBullet_Call = g_Pattern.Find(L"client.dll", L"83 C4 ? 5F 5E 5B 8B E5 5D C2 ? ? CC CC CC CC 53");
 	if (reinterpret_cast<DWORD>(_ReturnAddress()) != C_TFWeaponBaseGun__FireBullet_Call)

--- a/Fedoraware/TeamFortress2/TeamFortress2/Hooks/Detours/FX_FireBullets.cpp
+++ b/Fedoraware/TeamFortress2/TeamFortress2/Hooks/Detours/FX_FireBullets.cpp
@@ -1,12 +1,14 @@
 #include "../Hooks.h"
 #include "../../Features/Backtrack/Backtrack.h"
 #include "../../Features/Resolver/Resolver.h"
+#include "../../Features/AntiHack/CheaterDetection/CheaterDetection.h"
 
 MAKE_HOOK(FX_FireBullets, g_Pattern.Find(L"client.dll", L"55 8B EC 81 EC ? ? ? ? 53 8B 5D ? 56 53"), void, __cdecl,
 	void *pWpn, int iPlayer, const Vec3 &vecOrigin, const Vec3 &vecAngles, int iWeapon, int iMode, int iSeed, float flSpread, float flDamage, bool bCritical)
 {
 	F::BacktrackNew.ReportShot(iPlayer);
 	F::Resolver.ReportShot(iPlayer);
+	F::BadActors.ReportShot(iPlayer);
 
 	static auto C_TFWeaponBaseGun__FireBullet_Call = g_Pattern.Find(L"client.dll", L"83 C4 ? 5F 5E 5B 8B E5 5D C2 ? ? CC CC CC CC 53");
 	if (reinterpret_cast<DWORD>(_ReturnAddress()) != C_TFWeaponBaseGun__FireBullet_Call)

--- a/Fedoraware/TeamFortress2/TeamFortress2/Hooks/Detours/FX_FireBullets.cpp
+++ b/Fedoraware/TeamFortress2/TeamFortress2/Hooks/Detours/FX_FireBullets.cpp
@@ -10,7 +10,7 @@ MAKE_HOOK(FX_FireBullets, g_Pattern.Find(L"client.dll", L"55 8B EC 81 EC ? ? ? ?
 	F::Resolver.ReportShot(iPlayer);
 	F::BadActors.ReportShot(iPlayer);
 
-	Utils::ConLog("FX_FireBullets", tfm::format("Entity[%d]", iPlayer).c_str(), {0, 222, 255, 255});
+	//Utils::ConLog("FX_FireBullets", tfm::format("Entity[%d]", iPlayer).c_str(), {0, 222, 255, 255});
 
 	static auto C_TFWeaponBaseGun__FireBullet_Call = g_Pattern.Find(L"client.dll", L"83 C4 ? 5F 5E 5B 8B E5 5D C2 ? ? CC CC CC CC 53");
 	if (reinterpret_cast<DWORD>(_ReturnAddress()) != C_TFWeaponBaseGun__FireBullet_Call)

--- a/Fedoraware/TeamFortress2/TeamFortress2/Hooks/Detours/ModelRender_DrawModelExecute.cpp
+++ b/Fedoraware/TeamFortress2/TeamFortress2/Hooks/Detours/ModelRender_DrawModelExecute.cpp
@@ -76,7 +76,8 @@ void DrawBT(void* ecx, void* edx, CBaseEntity* pEntity, const DrawModelState_t& 
 
 				if (Vars::Backtrack::BtChams::LastOnly.Value)
 				{
-					const auto& vLastRec = F::BacktrackNew.GetRecord(pEntity, BacktrackMode::Last);
+					const auto& vRecords = F::BacktrackNew.GetRecords(pEntity);
+					std::optional<TickRecordNew> vLastRec = vRecords->back();
 					if (vLastRec)
 					{
 						OriginalFn(ecx, edx, pState, pInfo, (matrix3x4*)(&vLastRec->BoneMatrix));
@@ -89,7 +90,7 @@ void DrawBT(void* ecx, void* edx, CBaseEntity* pEntity, const DrawModelState_t& 
 					{
 						for (auto& record : *vRecords)
 						{
-							OriginalFn(ecx, edx, pState, pInfo, (matrix3x4*)(&record.BoneMatrix));
+							if (F::BacktrackNew.WithinRewind(record)) { OriginalFn(ecx, edx, pState, pInfo, (matrix3x4*)(&record.BoneMatrix)); }
 						}
 					}
 				}

--- a/Fedoraware/TeamFortress2/TeamFortress2/Hooks/Detours/ModelRender_DrawModelExecute.cpp
+++ b/Fedoraware/TeamFortress2/TeamFortress2/Hooks/Detours/ModelRender_DrawModelExecute.cpp
@@ -15,7 +15,7 @@ MAKE_HOOK(ModelRender_DrawModelExecute, Utils::GetVFuncPtr(I::ModelRender, 19), 
 
 	CBaseEntity* pEntity = I::ClientEntityList->GetClientEntity(pInfo.m_nEntIndex);
 
-	//DrawBT(ecx, edx, pEntity, pState, pInfo, pBoneToWorld);
+	DrawBT(ecx, edx, pEntity, pState, pInfo, pBoneToWorld);
 
 
 	if (!F::Glow.m_bRendering) {
@@ -25,89 +25,86 @@ MAKE_HOOK(ModelRender_DrawModelExecute, Utils::GetVFuncPtr(I::ModelRender, 19), 
 	Hook.Original<FN>()(ecx, edx, pState, pInfo, pBoneToWorld);
 }
 
-//void DrawBT(void* ecx, void* edx, CBaseEntity* pEntity, const DrawModelState_t& pState, const ModelRenderInfo_t& pInfo,
-//			matrix3x4* pBoneToWorld)
-//{
-//	auto OriginalFn = Hooks::ModelRender_DrawModelExecute::Hook.Original<Hooks::ModelRender_DrawModelExecute::FN>();
-//
-//	if (G::CurWeaponType == EWeaponType::PROJECTILE) return;
-//
-//	if (Vars::Backtrack::Enabled.Value && Vars::Backtrack::BtChams::Enabled.Value)
-//	{
-//		if (pEntity && pEntity->GetClassID() == ETFClassID::CTFPlayer)
-//		{
-//			if (!pEntity->IsAlive())
-//			{
-//				return;
-//			}
-//
-//			if (pEntity->m_vecVelocity().Length2D() < 5.f)
-//			{
-//				return;
-//			}
-//			if (!F::Glow.m_bRendering && !F::Chams.m_bRendering)
-//			{
-//				if (Vars::Backtrack::BtChams::EnemyOnly.Value && g_EntityCache.GetLocal() && pEntity->GetTeamNum() ==
-//					g_EntityCache.GetLocal()->GetTeamNum())
-//				{
-//					return;
-//				}
-//
-//				IMaterial* chosenMat = F::DMEChams.v_MatList.at(Vars::Backtrack::BtChams::Material.Value) ? F::DMEChams.v_MatList.at(Vars::Backtrack::BtChams::Material.Value) : nullptr;
-//
-//				I::ModelRender->ForcedMaterialOverride(chosenMat);
-//
-//				if (chosenMat)
-//				{
-//					I::RenderView->SetColorModulation(
-//						Color::TOFLOAT(Vars::Backtrack::BtChams::BacktrackColor.r),
-//						Color::TOFLOAT(Vars::Backtrack::BtChams::BacktrackColor.g),
-//						Color::TOFLOAT(Vars::Backtrack::BtChams::BacktrackColor.b));
-//				}
-//
-//
-//				if (const auto& pRenderContext = I::MaterialSystem->GetRenderContext())
-//				{
-//					if (Vars::Backtrack::BtChams::IgnoreZ.Value)
-//						pRenderContext->DepthRange(0.0f, 0.2f);
-//				}
-//
-//				I::RenderView->SetBlend(Color::TOFLOAT(Vars::Backtrack::BtChams::BacktrackColor.a));
-//
-//				if (Vars::Backtrack::BtChams::LastOnly.Value)
-//				{
-//					const auto& lastRecord = F::Backtrack.GetRecord(pEntity->GetIndex(), BacktrackMode::Last);
-//					if (lastRecord)
-//					{
-//						OriginalFn(ecx, edx, pState, pInfo, (matrix3x4*)(&lastRecord->BoneMatrix));
-//					}
-//				}
-//				else
-//				{
-//					const auto& entRecords = F::Backtrack.GetPlayerRecords(pEntity->GetIndex());
-//					if (entRecords)
-//					{
-//						for (auto& record : *entRecords)
-//						{
-//							if (F::Backtrack.IsTickInRange(record.TickCount))
-//							{
-//								OriginalFn(ecx, edx, pState, pInfo, (matrix3x4*)(&record.BoneMatrix));
-//							}
-//						}
-//					}
-//				}
-//
-//				I::ModelRender->ForcedMaterialOverride(nullptr);
-//				I::RenderView->SetColorModulation(1.0f, 1.0f, 1.0f);
-//				I::RenderView->SetBlend(1.0f);
-//
-//				if (const auto& pRenderContext = I::MaterialSystem->GetRenderContext())
-//				{
-//					if (Vars::Backtrack::BtChams::IgnoreZ.Value)
-//						pRenderContext->DepthRange(0.0f, 1.0f);
-//				}
-//			}
-//		}
-//	}
-//}
+void DrawBT(void* ecx, void* edx, CBaseEntity* pEntity, const DrawModelState_t& pState, const ModelRenderInfo_t& pInfo,
+			matrix3x4* pBoneToWorld)
+{
+	auto OriginalFn = Hooks::ModelRender_DrawModelExecute::Hook.Original<Hooks::ModelRender_DrawModelExecute::FN>();
+
+	if (G::CurWeaponType == EWeaponType::PROJECTILE) return;
+
+	if (Vars::Backtrack::Enabled.Value && Vars::Backtrack::BtChams::Enabled.Value)
+	{
+		if (pEntity && pEntity->GetClassID() == ETFClassID::CTFPlayer)
+		{
+			if (!pEntity->IsAlive())
+			{
+				return;
+			}
+
+			if (pEntity->m_vecVelocity().Length2D() < 5.f)
+			{
+				return;
+			}
+			if (!F::Glow.m_bRendering && !F::Chams.m_bRendering)
+			{
+				if (Vars::Backtrack::BtChams::EnemyOnly.Value && g_EntityCache.GetLocal() && pEntity->GetTeamNum() ==
+					g_EntityCache.GetLocal()->GetTeamNum())
+				{
+					return;
+				}
+
+				IMaterial* chosenMat = F::DMEChams.v_MatList.at(Vars::Backtrack::BtChams::Material.Value) ? F::DMEChams.v_MatList.at(Vars::Backtrack::BtChams::Material.Value) : nullptr;
+
+				I::ModelRender->ForcedMaterialOverride(chosenMat);
+
+				if (chosenMat)
+				{
+					I::RenderView->SetColorModulation(
+						Color::TOFLOAT(Vars::Backtrack::BtChams::BacktrackColor.r),
+						Color::TOFLOAT(Vars::Backtrack::BtChams::BacktrackColor.g),
+						Color::TOFLOAT(Vars::Backtrack::BtChams::BacktrackColor.b));
+				}
+
+
+				if (const auto& pRenderContext = I::MaterialSystem->GetRenderContext())
+				{
+					if (Vars::Backtrack::BtChams::IgnoreZ.Value)
+						pRenderContext->DepthRange(0.0f, 0.2f);
+				}
+
+				I::RenderView->SetBlend(Color::TOFLOAT(Vars::Backtrack::BtChams::BacktrackColor.a));
+
+				if (Vars::Backtrack::BtChams::LastOnly.Value)
+				{
+					const auto& vLastRec = F::BacktrackNew.GetRecord(pEntity, BacktrackMode::Last);
+					if (vLastRec)
+					{
+						OriginalFn(ecx, edx, pState, pInfo, (matrix3x4*)(&vLastRec->BoneMatrix));
+					}
+				}
+				else
+				{
+					const auto& vRecords = F::BacktrackNew.GetRecords(pEntity);
+					if (vRecords)
+					{
+						for (auto& record : *vRecords)
+						{
+							OriginalFn(ecx, edx, pState, pInfo, (matrix3x4*)(&record.BoneMatrix));
+						}
+					}
+				}
+
+				I::ModelRender->ForcedMaterialOverride(nullptr);
+				I::RenderView->SetColorModulation(1.0f, 1.0f, 1.0f);
+				I::RenderView->SetBlend(1.0f);
+
+				if (const auto& pRenderContext = I::MaterialSystem->GetRenderContext())
+				{
+					if (Vars::Backtrack::BtChams::IgnoreZ.Value)
+						pRenderContext->DepthRange(0.0f, 1.0f);
+				}
+			}
+		}
+	}
+}
 

--- a/Fedoraware/TeamFortress2/TeamFortress2/Hooks/Detours/ModelRender_DrawModelExecute.cpp
+++ b/Fedoraware/TeamFortress2/TeamFortress2/Hooks/Detours/ModelRender_DrawModelExecute.cpp
@@ -69,10 +69,10 @@ void DrawBT(void* ecx, void* edx, CBaseEntity* pEntity, const DrawModelState_t& 
 
 				I::RenderView->SetBlend(Color::TOFLOAT(Vars::Backtrack::BtChams::BacktrackColor.a));
 
+				const auto& vRecords = F::BacktrackNew.GetRecords(pEntity);
 				if (Vars::Backtrack::BtChams::LastOnly.Value)
 				{
-					const auto& vRecords = F::BacktrackNew.GetRecords(pEntity);
-					std::optional<TickRecordNew> vLastRec = vRecords->back();
+					std::optional<TickRecordNew> vLastRec = F::BacktrackNew.GetLastRecord(pEntity);
 					if (vLastRec)
 					{
 						OriginalFn(ecx, edx, pState, pInfo, (matrix3x4*)(&vLastRec->BoneMatrix));
@@ -80,7 +80,6 @@ void DrawBT(void* ecx, void* edx, CBaseEntity* pEntity, const DrawModelState_t& 
 				}
 				else
 				{
-					const auto& vRecords = F::BacktrackNew.GetRecords(pEntity);
 					if (vRecords)
 					{
 						for (auto& record : *vRecords)

--- a/Fedoraware/TeamFortress2/TeamFortress2/Hooks/Detours/ModelRender_DrawModelExecute.cpp
+++ b/Fedoraware/TeamFortress2/TeamFortress2/Hooks/Detours/ModelRender_DrawModelExecute.cpp
@@ -40,11 +40,6 @@ void DrawBT(void* ecx, void* edx, CBaseEntity* pEntity, const DrawModelState_t& 
 			{
 				return;
 			}
-
-			if (pEntity->m_vecVelocity().Length2D() < 5.f)
-			{
-				return;
-			}
 			if (!F::Glow.m_bRendering && !F::Chams.m_bRendering)
 			{
 				if (Vars::Backtrack::BtChams::EnemyOnly.Value && g_EntityCache.GetLocal() && pEntity->GetTeamNum() ==

--- a/Fedoraware/TeamFortress2/TeamFortress2/Hooks/Detours/NetChannel_SendDatagram.cpp
+++ b/Fedoraware/TeamFortress2/TeamFortress2/Hooks/Detours/NetChannel_SendDatagram.cpp
@@ -3,21 +3,21 @@
 
 MAKE_HOOK(NetChannel_SendDatagram, g_Pattern.Find(L"engine.dll", L"55 8B EC B8 ? ? ? ? E8 ? ? ? ? A1 ? ? ? ? 53 56 8B D9"), int, __fastcall, INetChannel* netChannel, void* edx, bf_write* datagram)
 {
-	if (CBaseEntity* pLocal = g_EntityCache.GetLocal(); !pLocal || !pLocal->IsAlive() || pLocal->IsAGhost()){ F::Backtrack.AllowLatency = false; return Hook.Original<FN>()(netChannel, edx, datagram); }
+	if (CBaseEntity* pLocal = g_EntityCache.GetLocal(); !pLocal || !pLocal->IsAlive() || pLocal->IsAGhost()){ F::BacktrackNew.bFakeLatency = false; return Hook.Original<FN>()(netChannel, edx, datagram); }
 	if (!Vars::Backtrack::Enabled.Value || !Vars::Backtrack::FakeLatency.Value || Vars::Backtrack::Latency.Value <= 4.f
 		|| !netChannel || netChannel->IsLoopback()
 		|| !I::EngineClient->IsConnected() || !I::EngineClient->IsInGame() || I::EngineClient->IsDrawingLoadingImage())
 	{
-		F::Backtrack.AllowLatency = false;
+		F::BacktrackNew.bFakeLatency = false;
 		return Hook.Original<FN>()(netChannel, edx, datagram);
 	}
 
-	//F::Backtrack.AllowLatency = true;
+	F::BacktrackNew.bFakeLatency = true;
 	
 	const int inSequence = netChannel->m_nInSequenceNr;
 	const int inState = netChannel->m_nInReliableState;
 
-	//F::Backtrack.AdjustPing(netChannel);
+	F::BacktrackNew.AdjustPing(netChannel);
 
 	const int original = Hook.Original<FN>()(netChannel, edx, datagram);
 	netChannel->m_nInSequenceNr = inSequence;

--- a/Fedoraware/TeamFortress2/TeamFortress2/Hooks/Detours/ViewRender_LevelInit.cpp
+++ b/Fedoraware/TeamFortress2/TeamFortress2/Hooks/Detours/ViewRender_LevelInit.cpp
@@ -2,6 +2,7 @@
 
 #include "../../Features/Visuals/Visuals.h"
 #include "../../Features/Backtrack/Backtrack.h"
+#include "../../Features/TickHandler/TickHandler.h"
 
 #include "../../Features/Misc/Misc.h"
 
@@ -17,4 +18,5 @@ MAKE_HOOK(ViewRender_LevelInit, Utils::GetVFuncPtr(I::ViewRender, 1), void, __fa
 
 	F::Visuals.ModulateWorld();
 	F::BacktrackNew.Restart();
+	F::Ticks.Reset();
 }

--- a/Fedoraware/TeamFortress2/TeamFortress2/Hooks/Detours/ViewRender_LevelInit.cpp
+++ b/Fedoraware/TeamFortress2/TeamFortress2/Hooks/Detours/ViewRender_LevelInit.cpp
@@ -3,6 +3,7 @@
 #include "../../Features/Visuals/Visuals.h"
 #include "../../Features/Backtrack/Backtrack.h"
 #include "../../Features/TickHandler/TickHandler.h"
+#include "../../Features/AntiHack/CheaterDetection/CheaterDetection.h"
 
 #include "../../Features/Misc/Misc.h"
 
@@ -19,4 +20,5 @@ MAKE_HOOK(ViewRender_LevelInit, Utils::GetVFuncPtr(I::ViewRender, 1), void, __fa
 	F::Visuals.ModulateWorld();
 	F::BacktrackNew.Restart();
 	F::Ticks.Reset();
+	F::BadActors.OnLoad();
 }

--- a/Fedoraware/TeamFortress2/TeamFortress2/SDK/Main/BaseCombatWeapon/BaseCombatWeapon.h
+++ b/Fedoraware/TeamFortress2/TeamFortress2/SDK/Main/BaseCombatWeapon/BaseCombatWeapon.h
@@ -238,7 +238,7 @@ public: //Everything else, lol
 		bool bResult = false;
 		if (const auto& pOwner = I::ClientEntityList->GetClientEntityFromHandle(GethOwner()))
 		{
-			const int nOldFov = pOwner->GetFov(); pOwner->SetFov(70);
+			const int nOldFov = pOwner->GetFov(); pOwner->SetFov(-1);
 			bResult = GetVFunc<bool(__thiscall*)(decltype(this), bool, CBaseEntity*)>(this, 424)(this, bHeadShot, nullptr);
 			pOwner->SetFov(nOldFov);
 		} return bResult;

--- a/Fedoraware/TeamFortress2/TeamFortress2/SDK/Main/BaseEntity/BaseEntity.h
+++ b/Fedoraware/TeamFortress2/TeamFortress2/SDK/Main/BaseEntity/BaseEntity.h
@@ -455,7 +455,7 @@ public: //Everything else, lol.
 	__inline bool IsVulnerable() {
 		int nCond = GetCond();
 		int nCondEx = GetCondEx();
-		return !(nCond & TFCond_Ubercharged || nCond & TFCond_Bonked || nCondEx & TFCondEx_PhlogUber || nCondEx & TFCondEx_UberchargedHidden || nCondEx & TFCondEx_UberchargedCanteen);
+		return !(nCond & TFCond_Ubercharged || nCond & TFCond_Bonked || nCondEx & TFCondEx_PyroHeal || nCondEx & TFCondEx_UberchargedHidden || nCondEx & TFCondEx_UberchargedCanteen);
 	}
 
 	__inline bool IsVisible() {

--- a/Fedoraware/TeamFortress2/TeamFortress2/SDK/Main/BaseEntity/BaseEntity.h
+++ b/Fedoraware/TeamFortress2/TeamFortress2/SDK/Main/BaseEntity/BaseEntity.h
@@ -455,7 +455,7 @@ public: //Everything else, lol.
 	__inline bool IsVulnerable() {
 		int nCond = GetCond();
 		int nCondEx = GetCondEx();
-		return !(nCond & TFCond_Ubercharged || nCond & TFCond_Bonked || nCondEx & TFCondEx_PyroHeal || nCondEx & TFCondEx_UberchargedHidden || nCondEx & TFCondEx_UberchargedCanteen);
+		return !(nCond & TFCond_Ubercharged || nCond & TFCond_Bonked || nCondEx & TFCondEx_UberchargedHidden || nCondEx & TFCondEx_UberchargedCanteen);
 	}
 
 	__inline bool IsVisible() {

--- a/Fedoraware/TeamFortress2/TeamFortress2/SDK/Main/PlayerResource/PlayerResource.h
+++ b/Fedoraware/TeamFortress2/TeamFortress2/SDK/Main/PlayerResource/PlayerResource.h
@@ -165,4 +165,11 @@ public:
 		static auto offset = g_NetVars.get_offset("DT_TFPlayerResource", "m_iStreaks");
 		return reinterpret_cast<int*>(this + offset + 4 * idx);
 	}
+
+	float GetConnectionTime(int idx)
+	{
+		if (!this) { return 0.f; }
+		static auto offset = g_NetVars.get_offset("DT_TFPlayerResource", "m_flConnectTime");
+		return *reinterpret_cast<float*>(this + offset + 4 * idx);
+	}
 };

--- a/Fedoraware/TeamFortress2/TeamFortress2/Utils/Events/Events.cpp
+++ b/Fedoraware/TeamFortress2/TeamFortress2/Utils/Events/Events.cpp
@@ -2,6 +2,7 @@
 #include "../../Features/ChatInfo/ChatInfo.h"
 #include "../../Features/Resolver/Resolver.h"
 #include "../../Features/AntiHack/AntiAim.h"
+#include "../../Features/AntiHack/CheaterDetection/CheaterDetection.h"
 #include "../../Features/Visuals/Visuals.h"
 #include "../../Features/Killstreak/Killstreak.h"
 #include "../../Features/LuaEngine/Callbacks/LuaCallbacks.h"
@@ -39,6 +40,7 @@ void CEventListener::FireGameEvent(CGameEvent* pEvent) {
 	{
 		F::Resolver.OnPlayerHurt(pEvent);
 		F::BacktrackNew.PlayerHurt(pEvent);
+		F::BadActors.ReportDamage(pEvent);
 	}
 
 	// Run Lua callbacks

--- a/Fedoraware/TeamFortress2/TeamFortress2/Utils/Events/Events.cpp
+++ b/Fedoraware/TeamFortress2/TeamFortress2/Utils/Events/Events.cpp
@@ -5,6 +5,7 @@
 #include "../../Features/Visuals/Visuals.h"
 #include "../../Features/Killstreak/Killstreak.h"
 #include "../../Features/LuaEngine/Callbacks/LuaCallbacks.h"
+#include "../../Features/Backtrack/Backtrack.h"
 
 void CEventListener::Setup(const std::deque<const char*>& deqEvents)
 {
@@ -35,6 +36,7 @@ void CEventListener::FireGameEvent(CGameEvent* pEvent) {
 	if (uNameHash == FNV1A::HashConst("player_hurt"))
 	{
 		F::Resolver.OnPlayerHurt(pEvent);
+		F::BacktrackNew.PlayerHurt(pEvent);
 	}
 
 	// Run Lua callbacks


### PR DESCRIPTION
### Remade backtrack, added;
> Legit backtrack
 Different backtrack modes

### Remade Cheater Detection, added;
> Aimbot detection (WIP)
 Better fakelag detection
 Statistical detection (players performing unusually well)
 Better bhop detection
 Duck Speedhack detection
 More customization for all detection options

### Improved Aimbot
> Players can now choose to ignore certain hitboxes on players that are moving (credits to lbox ig)
 Your priority hitbox WILL still override the static hitboxes selection.

### Improved Tickbase Manip
> You can now passively charge ticks
 Force safe tick in air
 Fakelag while in air (only works properly below 14 ticks)
 Fixes to how the cheat stored ticks

### Misc
> Improved bunnyhop
 Added edge resolver mode (untested)
 Disable resolver on players who are having their angles held by the server
 Fixed an issue with CanFireCriticalShot returning false if your FoV was 70
 Fixed an issue with manual anti aim using the invert key

and probably some other things I can't remember