### PR TITLE
seperate bounce key and feetaim

### DIFF
--- a/Fedoraware/TeamFortress2/TeamFortress2/Features/Aimbot/AimbotProjectile/AimbotProjectile.cpp
+++ b/Fedoraware/TeamFortress2/TeamFortress2/Features/Aimbot/AimbotProjectile/AimbotProjectile.cpp
@@ -593,7 +593,7 @@ Vec3 CAimbotProjectile::GetAimPos(CBaseEntity* pLocal, CBaseEntity* pEntity, con
 		}
 		case CLASS_DEMOMAN:
 		{
-			if (pEntity->OnSolid() && (Vars::Aimbot::Projectile::FeetAimIfOnGround.Value && (bounceKey.Down() || !Vars::Aimbot::Projectile::BounceKey.Value)))
+			if (bounceKey.Down() || (pEntity->OnSolid() && (Vars::Aimbot::Projectile::FeetAimIfOnGround.Value)))
 			{
 				aimMethod = 2;
 			}


### PR DESCRIPTION
Noticed that bounceKey wasn't working when the enemy was bunnyhopping, so I fixed the code back to its original intention.
BounceKey is supposed to be seperate from feet aim, to where you can use bounceKey while feetAim is turned off.

I feel as though "fee aim on ground" is a more automated method of bouncing the target, however it has nothing to do with targets in the air. Also, constantly aiming at the feet with soldier is suspicious af and has gotten me called out on multiple occasions.
Alternatively, I want to be able to use bounceKey to send enemies flying up higher when using soldier/demoman. As it currently stands, aimbot set to auto hitbox will aim for the knees- as I stated a few commits ago this is nice for accuracy, but if the user is _manually_ holding the bounce key, they 100% want to aim for the feet. With this, if I'm not holding the boucnekey and feetAim is disabled, I'll aim at the chest automatically- which is perfect for looking legit and not always aiming at the bottom of the hitbox.

