### PR TITLE
Removing friends array, bit level hacking 

### DIFF
--- a/Fedoraware/TeamFortress2/TeamFortress2/SDK/Main/EntityCache/EntityCache.cpp
+++ b/Fedoraware/TeamFortress2/TeamFortress2/SDK/Main/EntityCache/EntityCache.cpp
@@ -212,12 +212,15 @@ void CEntityCache::UpdateFriends()
 	static size_t CurSize, OldSize;
 	const auto Players = GetGroup(EGroupType::PLAYERS_ALL);
 	CurSize = Players.size();
-
 	if (CurSize != OldSize)
 	{
+        uint_fast64_t mask;
+        bool flag;
 		for (const auto& Player : Players)
 		{
-			Friends[Player->GetIndex()] = IsPlayerOnSteamFriendList(Player);
+             mask = (uint_fast64_t)2 << Player->GetIndex();
+             flag = IsPlayerOnSteamFriendList(Player);
+             friends = (friends & ~mask) | (-flag & mask);
 		}
 	}
 
@@ -237,14 +240,6 @@ void CEntityCache::Clear()
 	}
 }
 
-bool CEntityCache::IsFriend(int entIdx)
-{
-	if (entIdx < 0 || entIdx >= 129)
-	{
-		return false;
-	}
-	return Friends[entIdx];
-}
 
 const std::vector<CBaseEntity*>& CEntityCache::GetGroup(const EGroupType& Group)
 {

--- a/Fedoraware/TeamFortress2/TeamFortress2/SDK/Main/EntityCache/EntityCache.h
+++ b/Fedoraware/TeamFortress2/TeamFortress2/SDK/Main/EntityCache/EntityCache.h
@@ -23,9 +23,11 @@ class CEntityCache
 	void UpdateFriends();
 
 public:
+
 	void Fill();
 	void Clear();
-	bool IsFriend(int entIdx);
+    uint_fast64_t friends;
+    bool IsFriend(int entIdx) { return (friends >> entIdx) & 1; }
 
 	CBaseEntity* GetLocal() { return m_pLocal; }
 	CBaseCombatWeapon* GetWeapon() { return m_pLocalWeapon; }
@@ -33,7 +35,6 @@ public:
 	CTFPlayerResource* GetPR() { return m_pPlayerResource; }
 
 	const std::vector<CBaseEntity*>& GetGroup(const EGroupType& Group);
-	bool Friends[129] = { false };
 };
 
 inline CEntityCache g_EntityCache;


### PR DESCRIPTION
It really is a waste of memory to have an array of 129 bools (-- The max player IDX should be 32 anyway). You can just store all of your friends as bits. I also removed the IDX checks since by default it's using a player and their IDX should never be outside 1-32.