### PR TITLE
Melee Aimbot Rewrite

### DIFF
--- a/Fedoraware/Fedoraware-TF2/src/Features/Aimbot/AimbotGlobal/AimbotGlobal.cpp
+++ b/Fedoraware/Fedoraware-TF2/src/Features/Aimbot/AimbotGlobal/AimbotGlobal.cpp
@@ -92,6 +92,7 @@ bool CAimbotGlobal::ShouldIgnore(CBaseEntity* pTarget, bool hasMedigun)
 
 	PlayerInfo_t pInfo{};
 	if (!pTarget) { return true; }
+	if (pTarget == pLocal) { return true; }
 	if (!I::EngineClient->GetPlayerInfo(pTarget->GetIndex(), &pInfo)) { return true; }
 	if (pTarget->GetDormant()) { return true; }
 	if (Vars::Aimbot::Global::IgnoreOptions.Value & (CLOAKED) && pTarget->IsVisible()) { return true; }

--- a/Fedoraware/Fedoraware-TF2/src/Features/Aimbot/AimbotMelee/AimbotMelee.cpp
+++ b/Fedoraware/Fedoraware-TF2/src/Features/Aimbot/AimbotMelee/AimbotMelee.cpp
@@ -1,323 +1,262 @@
 #include "AimbotMelee.h"
-#include "../../Vars.h"
-#include "../MovementSimulation/MovementSimulation.h"
-#include "../../TickHandler/TickHandler.h"
-#include "../../Backtrack/Backtrack.h"
 
-bool CAimbotMelee::CanMeleeHit(CBaseEntity* pLocal, CBaseCombatWeapon* pWeapon, const Vec3& vecViewAngles,
-	int nTargetIndex)
-{
-	static Vec3 vecSwingMins = { -18.0f, -18.0f, -18.0f };
-	static Vec3 vecSwingMaxs = { 18.0f, 18.0f, 18.0f };
-
-	const float flRange = (pWeapon->GetSwingRange(pLocal));
-
-	if (flRange <= 0.0f)
+void CAimbotMelee::Aim(CUserCmd* pCmd, Vec3& vAngle) {
+	vAngle -= G::PunchAngles;
+	Math::ClampAngles(vAngle);
+	switch (Vars::Aimbot::Melee::AimMethod.Value)
 	{
-		return false;
+	case 1: {
+		if (!Vars::Aimbot::Melee::SmoothingAmount.Value) { break; }
+		Vec3 vDelta = vAngle - pCmd->viewangles;
+		Math::ClampAngles(vDelta);
+		pCmd->viewangles += vDelta / Vars::Aimbot::Melee::SmoothingAmount.Value;
+		I::EngineClient->SetViewAngles(pCmd->viewangles);
+		return;
+	}
+	case 2: {
+		if (!G::IsAttacking) { return; }
+		G::SilentTime = true;
+		Utils::FixMovement(pCmd, vAngle);
+		pCmd->viewangles = vAngle;
+		return;
+	}
 	}
 
-	auto vecForward = Vec3();
-	Math::AngleVectors(vecViewAngles, &vecForward);
+	pCmd->viewangles = vAngle;
+	I::EngineClient->SetViewAngles(pCmd->viewangles);
+	return;
+}
 
-	Vec3 vecTraceStart = pLocal->GetShootPos();
-	const Vec3 vecTraceEnd = (vecTraceStart + (vecForward * flRange));
+bool CAimbotMelee::VerifyTarget(CBaseEntity* pLocal, CBaseCombatWeapon* pWeapon, Target_t& target) {
+	const Vec3& vLocalPos = vCache;
+	const Vec3& vLocalAngles = I::EngineClient->GetViewAngles();
+	//	not gonna movesim enemies this time cause we can just backtrack them.
+	//	check our current tick first
+	if (F::Backtrack.CanHitOriginal(target.m_pEntity)) {
+		Vec3 vTargetPoint{};
+		target.m_pEntity->GetCollision()->CalcNearestPoint(vLocalPos, &vTargetPoint);
+		target.m_vAngleTo = Math::CalcAngle(vLocalPos, vTargetPoint);
+		if (CanMeleeHit(pLocal, target.m_pEntity, pWeapon, target.m_vAngleTo)) {
+			target.SimTime = target.m_pEntity->GetSimulationTime();	//	technically we will end up backtracking unless we are using doubletap to instant melee, but i see that as a good thing
+			target.m_vPos = vTargetPoint;
+			return true;
+		}
+	}
+	//	check our backtrack ticks next.
+	if (CanBacktrack(target.m_pEntity)) {
+		if (std::deque<TickRecord>* pRecords = F::Backtrack.GetRecords(target.m_pEntity)) {
+			const Vec3 vOriginalPos = target.m_pEntity->GetAbsOrigin();
+			for (TickRecord& record : *pRecords) {
+				if (!F::Backtrack.WithinRewind(record, flSwingTime)) { continue; }
+				Vec3 vTargetPoint{};
+				target.m_pEntity->SetAbsOrigin(record.vOrigin);
+				target.m_pEntity->GetCollision()->CalcNearestPoint(vLocalPos, &vTargetPoint);
+				target.m_vAngleTo = Math::CalcAngle(vLocalPos, vTargetPoint);
+				if (CanMeleeHit(pLocal, target.m_pEntity, pWeapon, target.m_vAngleTo)) {
+
+					target.SimTime = record.flSimTime;
+					target.ShouldBacktrack = true;
+					target.m_vPos = vTargetPoint;
+					target.m_pEntity->SetAbsOrigin(vOriginalPos);
+					return true;
+				}
+			}
+			target.m_pEntity->SetAbsOrigin(vOriginalPos);
+		}
+	}
+	return false;
+}
+
+bool CAimbotMelee::FillCache(CBaseEntity* pLocal, CBaseCombatWeapon* pWeapon) {
+	flSwingTime = std::max(pWeapon->GetWeaponData().m_flSmackDelay - ((F::Ticks.MeleeDoubletapCheck(pLocal) && (Vars::Misc::CL_Move::AntiWarp.Value && pLocal->OnSolid())) ? TICKS_TO_TIME(G::ShiftedTicks) : 0.f), TICK_INTERVAL);
+	const int iTicks = TIME_TO_TICKS(flSwingTime);
+
+	if (Vars::Aimbot::Melee::PredictSwing.Value) {
+		if (F::MoveSim.Initialize(pLocal)) {
+			CMoveData moveData = {};
+			Vec3 absOrigin = {};
+			for (int i = 0; i < iTicks; i++) {
+				F::MoveSim.RunTick(moveData, absOrigin);
+			}
+			absOrigin += pLocal->GetViewOffset();
+			vCache = absOrigin;
+			F::MoveSim.Restore();
+		}
+		else { return false; }
+	}
+	else {
+		vCache = pLocal->GetShootPos();
+	}
+	return true;
+}
+
+bool CAimbotMelee::CanMeleeHit(CBaseEntity* pLocal, CBaseEntity* pEntity, CBaseCombatWeapon* pWeapon, const Vec3& vAngles) {
+	const float flHull = GetSwingVec(pLocal, pWeapon);
+	const float flRange = GetSwingRange(pLocal, pWeapon);
+
+	if (flRange <= 0.f) { return false; }
+
+	Vec3 vForward{};
+	Math::AngleVectors(vAngles, &vForward);
+
+	const Vec3 vTraceStart = vCache;
+	const Vec3 vTraceEnd = (vTraceStart + (vForward * flRange));
 
 	CTraceFilterHitscan filter;
 	filter.pSkip = pLocal;
 	CGameTrace trace;
-	Utils::TraceHull(vecTraceStart, vecTraceEnd, vecSwingMins, vecSwingMaxs, MASK_SHOT, &filter, &trace);
+	Utils::TraceHull(vTraceStart, vTraceEnd, { -flHull, -flHull, -flHull }, { flHull, flHull, flHull }, MASK_SHOT, &filter, &trace);
 
-	if (!(trace.entity && trace.entity->GetIndex() == nTargetIndex))
-	{
-		if (!Vars::Aimbot::Melee::PredictSwing.Value || pWeapon->GetWeaponID() == TF_WEAPON_KNIFE || pLocal->IsCharging())
-		{
-			return false;
-		}
-
-		const float FL_DELAY = std::max(pWeapon->GetWeaponData().m_flSmackDelay - ((F::Ticks.MeleeDoubletapCheck(pLocal) && (Vars::Misc::CL_Move::AntiWarp.Value && pLocal->OnSolid())) ? TICKS_TO_TIME(G::ShiftedTicks) : 0.f), TICK_INTERVAL);
-
-		const int iTicks = TIME_TO_TICKS(FL_DELAY);
-
-		if (!bCached) {
-			if (F::MoveSim.Initialize(g_EntityCache.GetLocal()))
-			{
-				CMoveData moveData = {};
-				Vec3 absOrigin = {};
-				for (int i = 0; i < iTicks; i++) {
-					F::MoveSim.RunTick(moveData, absOrigin);
-				}
-				vecTraceStart = absOrigin;
-				vecTraceStart.z += 64;	//	viewheight bcs lazy
-				bCached = true;
-				vCached = vecTraceStart;
-				F::MoveSim.Restore();
-			}
-			else { return false; }
-		}
-		else {
-			vecTraceStart = vCached;
-		}
-
-		CBaseEntity* pTarget = I::ClientEntityList->GetClientEntity(nTargetIndex);
-		if (!pTarget) { return false; }
-
-		if (pTarget->GetVelocity().Length() < 10.f || !pTarget->IsPlayer() || iTicks < 2) {
-			Vec3 vecTraceEnd = vecTraceStart + (vecForward * flRange);
-			Utils::TraceHull(vecTraceStart, vecTraceEnd, vecSwingMins, vecSwingMaxs, MASK_SHOT, &filter, &trace);
-			return (trace.entity && trace.entity == pTarget);
-		}
-
-		if (F::MoveSim.Initialize(pTarget)) {
-			CMoveData moveData = {};
-			Vec3 absOrigin = {};
-			for (int i = 0; i < iTicks; i++) {
-				F::MoveSim.RunTick(moveData, absOrigin);
-			}
-
-			const Vec3 vRestore = pTarget->GetAbsOrigin();
-			pTarget->SetAbsOrigin(absOrigin);
-
-			Vec3 vecTraceEnd = vecTraceStart + (vecForward * flRange);
-			Utils::TraceHull(vecTraceStart, vecTraceEnd, vecSwingMins, vecSwingMaxs, MASK_SHOT, &filter, &trace);
-			const bool bReturn = (trace.entity && trace.entity == pTarget);
-
-			pTarget->SetAbsOrigin(vRestore);
-			F::MoveSim.Restore();
-			return bReturn;
-		}
-
-		return false;
-	}
-
-	return true;
+	return trace.entity == pEntity;
 }
 
-EGroupType CAimbotMelee::GetGroupType(CBaseCombatWeapon* pWeapon)
-{
-	if (Vars::Aimbot::Melee::WhipTeam.Value && pWeapon->GetItemDefIndex() == Soldier_t_TheDisciplinaryAction)
-	{
-		return EGroupType::PLAYERS_ALL;
-	}
-
-	return EGroupType::PLAYERS_ENEMIES;
+inline bool CAimbotMelee::IsAttacking(const CUserCmd* pCmd, CBaseCombatWeapon* pWeapon) {
+	return pWeapon->GetWeaponID() == TF_WEAPON_KNIFE ? ((pCmd->buttons & IN_ATTACK) && G::WeaponCanAttack) : fabsf(pWeapon->GetSmackTime() - I::GlobalVars->curtime) < pWeapon->GetWeaponData().m_flSmackDelay;
 }
 
-/* Aim at friendly building with the wrench */
-bool CAimbotMelee::AimFriendlyBuilding(CBaseObject* pBuilding)
+inline bool CAimbotMelee::CanBacktrack(CBaseEntity* pEntity) {	//	truly despicable
+	return Vars::Backtrack::Enabled.Value && pEntity->IsPlayer();
+}
+
+inline float CAimbotMelee::GetSwingVec(CBaseEntity* pLocal, CBaseCombatWeapon* pWeapon) {
+	return 18.f * (Utils::ATTRIB_HOOK_FLOAT(1.f, "melee_bounds_multiplier", pWeapon, 0, true) * std::min(1.0f, pLocal->m_flModelScale()));
+}
+
+inline float CAimbotMelee::GetSwingRange(CBaseEntity* pLocal, CBaseCombatWeapon* pWeapon) {
+	return Vars::Aimbot::Melee::RangeCheck.Value ? Utils::ATTRIB_HOOK_FLOAT(pWeapon->GetSwingRange(pLocal) * std::min(1.0f, pLocal->m_flModelScale()), "melee_range_multiplier", pWeapon, 0, true) : 4096.f;
+}
+
+inline EGroupType CAimbotMelee::GetGroupType(CBaseCombatWeapon* pWeapon)
 {
-	if (pBuilding->GetLevel() != 3 || pBuilding->GetSapped() || pBuilding->GetHealth() < pBuilding->GetMaxHealth())
-	{
+	return static_cast<EGroupType>(Vars::Aimbot::Melee::WhipTeam.Value ? pWeapon->GetItemDefIndex() != Soldier_t_TheDisciplinaryAction : 1);
+}
+
+inline bool CAimbotMelee::IsPlayerValid(CBaseEntity* pTarget)
+{
+	//	return true if they are trans cause #transpplareVALID
+	return pTarget->IsAlive() && !pTarget->IsAGhost();
+}
+
+inline bool CAimbotMelee::TargetTeamBuilding(CBaseObject* pBuilding, CBaseCombatWeapon* pWeapon) {
+	if (pBuilding->GetSapped()) {
 		return true;
 	}
 
-	if (pBuilding->IsSentrygun())
-	{
-		int iShells;
-		int iMaxShells;
-		int iRockets;
-		int iMaxRockets;
+	//	Pyro Weps can't go any further
+	if (pWeapon->GetWeaponID() != TF_WEAPON_WRENCH) {
+		return false;
+	}
 
-		pBuilding->GetAmmoCount(iShells, iMaxShells, iRockets, iMaxRockets);
+	//	Upgrade/Heal Check
+	if (pBuilding->GetLevel() != 3 || pBuilding->GetHealth() < pBuilding->GetMaxHealth()) {
+		return true;
+	}
 
-		if (iShells < iMaxShells || iRockets < iMaxRockets)
-			return true;
+	//	Ammo Check
+	int iShells{};
+	int iMaxShells{};
+	int iRockets{};
+	int iMaxRockets{};
+
+	pBuilding->GetAmmoCount(iShells, iMaxShells, iRockets, iMaxRockets);
+	if (iShells < iMaxShells || iRockets < iMaxRockets) {
+		return true;
 	}
 
 	return false;
+}
+
+inline bool CAimbotMelee::TargetTeamBuildings(CBaseCombatWeapon* pWeapon) {
+	const bool bWrench = (pWeapon->GetWeaponID() == TF_WEAPON_WRENCH);
+	const bool bDamageSappers = Utils::ATTRIB_HOOK_FLOAT(0, "set_dmg_apply_to_sapper", pWeapon, 0, 1);
+	return bDamageSappers || bWrench;
 }
 
 std::vector<Target_t> CAimbotMelee::GetTargets(CBaseEntity* pLocal, CBaseCombatWeapon* pWeapon)
 {
-	std::vector<Target_t> validTargets;
-	const auto sortMethod = static_cast<ESortMethod>(Vars::Aimbot::Melee::SortMethod.Value);
+	std::vector<Target_t> vTargets{};
+	const ESortMethod sortMethod = static_cast<ESortMethod>(Vars::Aimbot::Melee::SortMethod.Value);
+	const Vec3& vLocalPos = pLocal->GetShootPos();
+	const Vec3& vLocalAngles = I::EngineClient->GetViewAngles();
+	const bool bRespectFOV = (sortMethod == ESortMethod::FOV || Vars::Aimbot::Melee::RespectFOV.Value);
 
-	const Vec3 vLocalPos = pLocal->GetShootPos();
-	const Vec3 vLocalAngles = I::EngineClient->GetViewAngles();
-
-	const bool respectFOV = (sortMethod == ESortMethod::FOV || Vars::Aimbot::Melee::RespectFOV.Value);
-
-	// Players
-	if (Vars::Aimbot::Global::AimPlayers.Value)
-	{
-		const auto groupType = GetGroupType(pWeapon);
-
-		for (const auto& pTarget : g_EntityCache.GetGroup(groupType))
-		{
-			// Is the target valid and alive?
-			if (!pTarget->IsAlive() || pTarget->IsAGhost() || pTarget == pLocal)
-			{
-				continue;
-			}
-
+	//	Players
+	if (Vars::Aimbot::Global::AimPlayers.Value) {
+		for (CBaseEntity* pTarget : g_EntityCache.GetGroup(GetGroupType(pWeapon))) {
+			if (!IsPlayerValid(pTarget)) { continue; }
 			if (F::AimbotGlobal.ShouldIgnore(pTarget, true)) { continue; }
 
-			Vec3 vPos = pTarget->GetHitboxPos(HITBOX_PELVIS);
-			Vec3 vAngleTo = Math::CalcAngle(vLocalPos, vPos);
+			const Vec3 vPos = pTarget->GetHitboxPos(HITBOX_PELVIS);
+			const Vec3 vAngleTo = Math::CalcAngle(vLocalPos, vPos);
 			const float flFOVTo = Math::CalcFov(vLocalAngles, vAngleTo);
 
-			if (respectFOV && flFOVTo > Vars::Aimbot::Global::AimFOV.Value)
-			{
+			if (bRespectFOV && flFOVTo > Vars::Aimbot::Global::AimFOV.Value) {
 				continue;
 			}
 
-			const auto& priority = F::AimbotGlobal.GetPriority(pTarget->GetIndex());
+			const Priority& priority = F::AimbotGlobal.GetPriority(pTarget->GetIndex());
 			const float flDistTo = vLocalPos.DistTo(vPos);
-			validTargets.push_back({ pTarget, ETargetType::PLAYER, vPos, vAngleTo, flFOVTo, flDistTo, -1, false, priority });
+			vTargets.push_back({ pTarget, ETargetType::PLAYER, vPos, vAngleTo, flFOVTo, flDistTo, -1, false, priority });
 		}
 	}
-
-	// Buildings
-	if (Vars::Aimbot::Global::AimBuildings.Value)
-	{
-		const bool hasWrench = (pWeapon->GetWeaponID() == TF_WEAPON_WRENCH);
-		const bool canDestroySapper = (G::CurItemDefIndex == Pyro_t_Homewrecker || G::CurItemDefIndex == Pyro_t_TheMaul || G::CurItemDefIndex == Pyro_t_NeonAnnihilator || G::CurItemDefIndex ==
-			Pyro_t_NeonAnnihilatorG);
-
-		for (const auto& pObject : g_EntityCache.GetGroup(hasWrench || canDestroySapper ? EGroupType::BUILDINGS_ALL : EGroupType::BUILDINGS_ENEMIES))
+	if (Vars::Aimbot::Global::AimBuildings.Value) {
+		for (CBaseEntity* pObject : g_EntityCache.GetGroup(TargetTeamBuildings(pWeapon) ? EGroupType::BUILDINGS_ALL : EGroupType::BUILDINGS_ENEMIES))
 		{
-			const auto& pBuilding = reinterpret_cast<CBaseObject*>(pObject);
+			CBaseObject* pBuilding = reinterpret_cast<CBaseObject*>(pObject);
 
-			// Is the building valid and alive?
-			if (!pObject || !pBuilding || !pObject->IsAlive())
-			{
+			if (!pObject || !pBuilding || !pObject->IsAlive()) {
 				continue;
 			}
 
-			if (hasWrench && (pBuilding->GetTeamNum() == pLocal->GetTeamNum()))
-			{
-				if (!AimFriendlyBuilding(pBuilding))
-				{
+			if (pBuilding->GetTeamNum() == pLocal->GetTeamNum()) {
+				if (!TargetTeamBuilding(pBuilding, pWeapon)) {
 					continue;
 				}
 			}
 
-			if (canDestroySapper && (pBuilding->GetTeamNum() == pLocal->GetTeamNum()))
-			{
-				if (!pBuilding->GetSapped())
-				{
-					continue;
-				}
-			}
-
-			Vec3 vPos = pObject->GetWorldSpaceCenter();
-			Vec3 vAngleTo = Math::CalcAngle(vLocalPos, vPos);
+			const Vec3 vPos = pObject->GetWorldSpaceCenter();
+			const Vec3 vAngleTo = Math::CalcAngle(vLocalPos, vPos);
 			const float flFOVTo = Math::CalcFov(vLocalAngles, vAngleTo);
 
-			if (respectFOV && flFOVTo > Vars::Aimbot::Global::AimFOV.Value)
-			{
+			if (bRespectFOV && flFOVTo > Vars::Aimbot::Global::AimFOV.Value) {
 				continue;
 			}
 
 			const float flDistTo = sortMethod == ESortMethod::DISTANCE ? vLocalPos.DistTo(vPos) : 0.0f;
-			validTargets.push_back({ pObject, ETargetType::BUILDING, vPos, vAngleTo, flFOVTo, flDistTo });
+			vTargets.push_back({ pObject, ETargetType::BUILDING, vPos, vAngleTo, flFOVTo, flDistTo });
 		}
 	}
-
-	// NPCs
 	if (Vars::Aimbot::Global::AimNPC.Value)
 	{
 		for (const auto& pNPC : g_EntityCache.GetGroup(EGroupType::WORLD_NPC))
 		{
-			Vec3 vPos = pNPC->GetWorldSpaceCenter();
-			Vec3 vAngleTo = Math::CalcAngle(vLocalPos, vPos);
+			const Vec3 vPos = pNPC->GetWorldSpaceCenter();
+			const Vec3 vAngleTo = Math::CalcAngle(vLocalPos, vPos);
 
 			const float flFOVTo = Math::CalcFov(vLocalAngles, vAngleTo);
 			const float flDistTo = sortMethod == ESortMethod::DISTANCE ? vLocalPos.DistTo(vPos) : 0.0f;
 
-			if (respectFOV && flFOVTo > Vars::Aimbot::Global::AimFOV.Value)
-			{
+			if (bRespectFOV && flFOVTo > Vars::Aimbot::Global::AimFOV.Value) {
 				continue;
 			}
 
-			validTargets.push_back({ pNPC, ETargetType::NPC, vPos, vAngleTo, flFOVTo, flDistTo });
+			vTargets.push_back({ pNPC, ETargetType::NPC, vPos, vAngleTo, flFOVTo, flDistTo });
 		}
 	}
 
-	return validTargets;
+	return vTargets;
 }
 
-bool CAimbotMelee::VerifyTarget(CBaseEntity* pLocal, CBaseCombatWeapon* pWeapon, Target_t& target)
-{
-	Vec3 hitboxpos;
+bool CAimbotMelee::GetTarget(CBaseEntity* pLocal, CBaseCombatWeapon* pWeapon) {
+	std::vector<Target_t> vTargets = GetTargets(pLocal, pWeapon);
+	if (vTargets.empty()) { return false; }
 
-	//Backtrack the target if required
-	if (Vars::Backtrack::Enabled.Value && target.m_TargetType == ETargetType::PLAYER)
-	{
-		if (const auto& pRecords = F::Backtrack.GetRecords(target.m_pEntity)) {
-			for (const auto& pTick : *pRecords)
-			{
-				if (!F::Backtrack.WithinRewind(pTick)) { continue; }
-				hitboxpos = target.m_pEntity->GetHitboxPosMatrix(HITBOX_PELVIS, (matrix3x4*)(&pTick.BoneMatrix));
+	const ESortMethod sortMethod = static_cast<ESortMethod>(Vars::Aimbot::Melee::SortMethod.Value);
+	F::AimbotGlobal.SortTargets(&vTargets, sortMethod);
 
-				if (Utils::VisPos(pLocal, target.m_pEntity, pLocal->GetShootPos(), hitboxpos)) {
-					target.SimTime = pTick.flSimTime;
-					target.m_vAngleTo = Math::CalcAngle(pLocal->GetShootPos(), hitboxpos);
-					target.m_vPos = hitboxpos;
-					target.ShouldBacktrack = true;
-				}
-			}
-		}
-		if (!F::Backtrack.CanHitOriginal(target.m_pEntity) && !target.ShouldBacktrack) // Check if the player is in range for a non-backtrack hit
-		{
-			return false;
-		}
-	}
-
-
-
-	if (Vars::Aimbot::Melee::RangeCheck.Value && !(target.ShouldBacktrack))
-	{
-		if (!CanMeleeHit(pLocal, pWeapon, target.m_vAngleTo, target.m_pEntity->GetIndex()))
-		{
-			return false;
-		}
-	}
-	else if (target.ShouldBacktrack)
-	{
-		const float FL_DELAY = std::max(pWeapon->GetWeaponData().m_flSmackDelay - ((F::Ticks.MeleeDoubletapCheck(pLocal) && (Vars::Misc::CL_Move::AntiWarp.Value && pLocal->OnSolid())) ? TICKS_TO_TIME(G::ShiftedTicks) : 0.f), TICK_INTERVAL);
-
-		if (F::MoveSim.Initialize(g_EntityCache.GetLocal()))
-		{
-			const int iTicks = TIME_TO_TICKS(FL_DELAY);
-			const Vec3 vPointDelta = pLocal->GetShootPos() - pLocal->GetAbsOrigin();
-			const float flRange = (pWeapon->GetSwingRange(pLocal)) * 1.9f;
-
-			CMoveData moveData = {};
-			Vec3 absOrigin = {};
-			for (int i = 0; i < iTicks; i++) {
-				F::MoveSim.RunTick(moveData, absOrigin);
-			}
-			const Vec3 vShootPos = absOrigin + vPointDelta;
-
-			const bool bInRange = hitboxpos.DistTo(vShootPos) < flRange;
-			F::MoveSim.Restore();
-			return bInRange;
-		}
-	}
-	else {
-		if (!Utils::VisPos(pLocal, target.m_pEntity, pLocal->GetShootPos(), target.m_vPos))
-		{
-			return false;
-		}
-	}
-
-	return true;
-}
-
-bool CAimbotMelee::GetTarget(CBaseEntity* pLocal, CBaseCombatWeapon* pWeapon, Target_t& outTarget)
-{
-	auto validTargets = GetTargets(pLocal, pWeapon);
-	if (validTargets.empty()) { return false; }
-
-	const auto& sortMethod = static_cast<ESortMethod>(Vars::Aimbot::Melee::SortMethod.Value);
-	F::AimbotGlobal.SortTargets(&validTargets, sortMethod);
-
-	for (auto& target : validTargets)
-	{
-		if (VerifyTarget(pLocal, pWeapon, target))
-		{
-			outTarget = target;
+	for (Target_t& target : vTargets) {
+		if (VerifyTarget(pLocal, pWeapon, target)) {
+			tTarget = target;
 			return true;
 		}
 	}
@@ -325,134 +264,34 @@ bool CAimbotMelee::GetTarget(CBaseEntity* pLocal, CBaseCombatWeapon* pWeapon, Ta
 	return false;
 }
 
-void CAimbotMelee::Aim(CUserCmd* pCmd, Vec3& vAngle)
-{
-	vAngle -= G::PunchAngles;
-	Math::ClampAngles(vAngle);
-
-	switch (Vars::Aimbot::Melee::AimMethod.Value)
-	{
-	case 0:
-	{
-		pCmd->viewangles = vAngle;
-		I::EngineClient->SetViewAngles(pCmd->viewangles);
-		break;
-	}
-
-	case 1:
-	{
-		if (Vars::Aimbot::Melee::SmoothingAmount.Value == 0)
-		{
-			// plain aim at 0 smoothing factor
-			pCmd->viewangles = vAngle;
-			I::EngineClient->SetViewAngles(pCmd->viewangles);
-			break;
-		}
-
-		Vec3 vecDelta = vAngle - pCmd->viewangles;
-		Math::ClampAngles(vecDelta);
-		pCmd->viewangles += vecDelta / Vars::Aimbot::Melee::SmoothingAmount.Value;
-		I::EngineClient->SetViewAngles(pCmd->viewangles);
-		break;
-	}
-
-	case 2:
-	{
-		Utils::FixMovement(pCmd, vAngle);
-		pCmd->viewangles = vAngle;
-		break;
-	}
-
-	default: break;
-	}
+inline bool CAimbotMelee::ShouldAttack() {
+	return Vars::Aimbot::Global::AutoShoot.Value;
 }
 
-bool CAimbotMelee::ShouldSwing(CBaseEntity* pLocal, CBaseCombatWeapon* pWeapon, CUserCmd* pCmd, const Target_t& Target)
-{
-	if (!Vars::Aimbot::Global::AutoShoot.Value)
-	{
-		return false;
-	}
-
-	if (Target.ShouldBacktrack) {
-		return true;
-	}
-
-	//There's a reason for running this even if range check is enabled (it calls this too), trust me :)
-	if (!CanMeleeHit(pLocal, pWeapon, Vars::Aimbot::Melee::AimMethod.Value == 2 ? Target.m_vAngleTo : I::EngineClient->GetViewAngles(), Target.m_pEntity->GetIndex()))
-	{
-		return false;
-	}
-
-	return true;
-}
-
-bool CAimbotMelee::IsAttacking(const CUserCmd* pCmd, CBaseCombatWeapon* pWeapon)
-{
-	if (pWeapon->GetWeaponID() == TF_WEAPON_KNIFE)
-	{
-		return ((pCmd->buttons & IN_ATTACK) && G::WeaponCanAttack);
-	}
-
-	return fabs(pWeapon->GetSmackTime() - I::GlobalVars->curtime) < I::GlobalVars->interval_per_tick * 2.0f;
-}
-
-void CAimbotMelee::Run(CBaseEntity* pLocal, CBaseCombatWeapon* pWeapon, CUserCmd* pCmd)
-{
-	bCached = false;
-
-	if (!Vars::Aimbot::Global::Active.Value || G::AutoBackstabRunning || pWeapon->GetWeaponID() == TF_WEAPON_KNIFE)
-	{
+void CAimbotMelee::Run(CBaseEntity* pLocal, CBaseCombatWeapon* pWeapon, CUserCmd* pCmd) {
+	const bool bShouldAim = (Vars::Aimbot::Melee::RequireBind.Value ? F::AimbotGlobal.IsKeyDown() : true);
+	if (!Vars::Aimbot::Global::Active.Value || G::AutoBackstabRunning || pWeapon->GetWeaponID() == TF_WEAPON_KNIFE || !bShouldAim) {
 		return;
 	}
+	FillCache(pLocal, pWeapon);
 
-	Target_t target = {};
-
-	const bool bShouldAim = (Vars::Aimbot::Melee::RequireBind.Value ? Vars::Aimbot::Global::AimKey.Value == VK_LBUTTON ? (pCmd->buttons & IN_ATTACK) : F::AimbotGlobal.IsKeyDown() : true);
-
-	if (GetTarget(pLocal, pWeapon, target) && bShouldAim)
-	{
-		G::CurrentTargetIdx = target.m_pEntity->GetIndex();
-
-		if (Vars::Aimbot::Melee::AimMethod.Value == 2)
-		{
-			G::AimPos = target.m_vPos;
-		}
-
-		// Early swing prediction
-		if (ShouldSwing(pLocal, pWeapon, pCmd, target))
-		{
+	if (GetTarget(pLocal, pWeapon)) {
+		if (ShouldAttack()) {
 			pCmd->buttons |= IN_ATTACK;
 		}
 
-		const bool bIsAttacking = IsAttacking(pCmd, pWeapon);
+		G::CurrentTargetIdx = tTarget.m_pEntity->GetIndex();
 
-		if (bIsAttacking)
-		{
-			G::IsAttacking = true;
-		}
-
-		// Set the target tickcount (Backtrack)
-		if (bIsAttacking && target.m_TargetType == ETargetType::PLAYER)
-		{
-			const float simTime = target.ShouldBacktrack ? target.SimTime : target.m_pEntity->GetSimulationTime();
-			pCmd->tick_count = TIME_TO_TICKS(simTime + G::LerpTime);
+		if (Vars::Aimbot::Melee::AimMethod.Value == 2) {
+			G::AimPos = tTarget.m_vPos;
 		}
 
-		if (Vars::Aimbot::Melee::AimMethod.Value == 2)
-		{
-			if (bIsAttacking)
-			{
-				Aim(pCmd, target.m_vAngleTo);
-				G::SilentTime = true;
-			}
+		G::IsAttacking = G::IsAttacking || IsAttacking(pCmd, pWeapon);
+
+		if (G::IsAttacking && tTarget.m_TargetType == ETargetType::PLAYER) {
+			pCmd->tick_count = TIME_TO_TICKS(tTarget.SimTime + G::LerpTime);
 		}
-		else
-		{
-			Aim(pCmd, target.m_vAngleTo);
-		}
-	}
-	else {
-		G::CurrentTargetIdx = 0;
+
+		Aim(pCmd, tTarget.m_vAngleTo);
 	}
 }

--- a/Fedoraware/Fedoraware-TF2/src/Features/Aimbot/AimbotMelee/AimbotMelee.cpp
+++ b/Fedoraware/Fedoraware-TF2/src/Features/Aimbot/AimbotMelee/AimbotMelee.cpp
@@ -266,6 +266,8 @@ inline bool CAimbotMelee::ShouldAttack() {
 }
 
 void CAimbotMelee::Run(CBaseEntity* pLocal, CBaseCombatWeapon* pWeapon, CUserCmd* pCmd) {
+	G::CurrentTargetIdx = 0;
+
 	const bool bShouldAim = (Vars::Aimbot::Melee::RequireBind.Value ? F::AimbotGlobal.IsKeyDown() : true);
 	if (!Vars::Aimbot::Global::Active.Value || G::AutoBackstabRunning || pWeapon->GetWeaponID() == TF_WEAPON_KNIFE || !bShouldAim) {
 		return;

--- a/Fedoraware/Fedoraware-TF2/src/Features/Aimbot/AimbotMelee/AimbotMelee.h
+++ b/Fedoraware/Fedoraware-TF2/src/Features/Aimbot/AimbotMelee/AimbotMelee.h
@@ -1,21 +1,32 @@
 #pragma once
 
 #include "../AimbotGlobal/AimbotGlobal.h"
+#include "../../Vars.h"
+#include "../MovementSimulation/MovementSimulation.h"
+#include "../../TickHandler/TickHandler.h"
+#include "../../Backtrack/Backtrack.h"
 
 class CAimbotMelee
 {
-	EGroupType GetGroupType(CBaseCombatWeapon* pWeapon);
-	bool AimFriendlyBuilding(CBaseObject* pBuilding);
-	bool CanMeleeHit(CBaseEntity* pLocal, CBaseCombatWeapon* pWeapon, const Vec3& vecViewAngles, int nTargetIndex);
+	inline EGroupType GetGroupType(CBaseCombatWeapon* pWeapon);
+	inline bool IsPlayerValid(CBaseEntity* pTarget);
+	inline bool TargetTeamBuilding(CBaseObject* pBuilding, CBaseCombatWeapon* pWeapon);
+	inline bool TargetTeamBuildings(CBaseCombatWeapon* pWeapon);
+	inline bool CanBacktrack(CBaseEntity* pEntity);
+	inline bool IsAttacking(const CUserCmd* pCmd, CBaseCombatWeapon* pWeapon);
+	inline bool ShouldAttack();
+	inline float GetSwingRange(CBaseEntity* pLocal, CBaseCombatWeapon* pWeapon);
+	inline float GetSwingVec(CBaseEntity* pLocal, CBaseCombatWeapon* pWeapon);
+	bool CanMeleeHit(CBaseEntity* pLocal, CBaseEntity* pEntity, CBaseCombatWeapon* pWeapon, const Vec3& vAngles);
+	bool FillCache(CBaseEntity* pLocal, CBaseCombatWeapon* pWeapon);
 	std::vector<Target_t> GetTargets(CBaseEntity* pLocal, CBaseCombatWeapon* pWeapon);
 	bool VerifyTarget(CBaseEntity* pLocal, CBaseCombatWeapon* pWeapon, Target_t& target);
-	bool GetTarget(CBaseEntity* pLocal, CBaseCombatWeapon* pWeapon, Target_t& outTarget);
+	bool GetTarget(CBaseEntity* pLocal, CBaseCombatWeapon* pWeapon);
 	void Aim(CUserCmd* pCmd, Vec3& vAngle);
-	bool ShouldSwing(CBaseEntity* pLocal, CBaseCombatWeapon* pWeapon, CUserCmd* pCmd, const Target_t& Target);
-	bool IsAttacking(const CUserCmd* pCmd, CBaseCombatWeapon* pWeapon);
 
-	bool bCached = false;
-	Vec3 vCached{};
+	float flSwingTime{};
+	Vec3 vCache{};
+	Target_t tTarget{};
 public:
 	void Run(CBaseEntity* pLocal, CBaseCombatWeapon* pWeapon, CUserCmd* pCmd);
 };

--- a/Fedoraware/Fedoraware-TF2/src/Features/Aimbot/AimbotMelee/AimbotMelee.h
+++ b/Fedoraware/Fedoraware-TF2/src/Features/Aimbot/AimbotMelee/AimbotMelee.h
@@ -17,7 +17,7 @@ class CAimbotMelee
 	inline bool ShouldAttack();
 	inline float GetSwingRange(CBaseEntity* pLocal, CBaseCombatWeapon* pWeapon);
 	inline float GetSwingVec(CBaseEntity* pLocal, CBaseCombatWeapon* pWeapon);
-	bool CanMeleeHit(CBaseEntity* pLocal, CBaseEntity* pEntity, CBaseCombatWeapon* pWeapon, const Vec3& vAngles);
+	inline bool CanMeleeHit(CBaseEntity* pLocal, CBaseEntity* pEntity, CBaseCombatWeapon* pWeapon, const Vec3& vAngles);
 	bool FillCache(CBaseEntity* pLocal, CBaseCombatWeapon* pWeapon);
 	std::vector<Target_t> GetTargets(CBaseEntity* pLocal, CBaseCombatWeapon* pWeapon);
 	bool VerifyTarget(CBaseEntity* pLocal, CBaseCombatWeapon* pWeapon, Target_t& target);

--- a/Fedoraware/Fedoraware-TF2/src/Features/Aimbot/AimbotProjectile/AimbotProjectile.cpp
+++ b/Fedoraware/Fedoraware-TF2/src/Features/Aimbot/AimbotProjectile/AimbotProjectile.cpp
@@ -1171,8 +1171,8 @@ bool CAimbotProjectile::GetSplashTarget(CBaseEntity* pLocal, CBaseCombatWeapon* 
 			continue;
 		}
 
-		const Vec3 vTargetCenter = pTarget->GetWorldSpaceCenter();
-		const Vec3 vTargetOrigin = pTarget->GetAbsOrigin();
+		const Vec3& vTargetCenter = pTarget->GetWorldSpaceCenter();
+		const Vec3& vTargetOrigin = pTarget->GetAbsOrigin();
 
 		if (vLocalOrigin.DistTo(vTargetOrigin) < Vars::Aimbot::Projectile::MinSplashPredictionDistance.Value) { continue; } // Don't shoot too close
 		if (vLocalOrigin.DistTo(vTargetOrigin) > Vars::Aimbot::Projectile::MaxSplashPredictionDistance.Value) { continue; } // Don't shoot too far
@@ -1195,7 +1195,7 @@ bool CAimbotProjectile::GetSplashTarget(CBaseEntity* pLocal, CBaseCombatWeapon* 
 			if ((sortMethod == ESortMethod::FOV || Vars::Aimbot::Projectile::RespectFOV.Value) && flFOVTo > Vars::Aimbot::Global::AimFOV.Value) { continue; }
 
 			// Can the target receive splash damage? (Don't predict through walls)
-			Utils::Trace(scanPos, pTarget->GetWorldSpaceCenter(), MASK_SOLID, &traceFilter, &trace);
+			Utils::Trace(scanPos, vTargetCenter, MASK_SOLID, &traceFilter, &trace);
 			if (trace.flFraction < 0.99f && trace.entity != pTarget) { continue; }
 
 			// Is the predicted position even visible?

--- a/Fedoraware/Fedoraware-TF2/src/Features/Aimbot/AimbotProjectile/AimbotProjectile.cpp
+++ b/Fedoraware/Fedoraware-TF2/src/Features/Aimbot/AimbotProjectile/AimbotProjectile.cpp
@@ -387,6 +387,7 @@ bool CAimbotProjectile::SolveProjectile(CBaseEntity* pLocal, CBaseCombatWeapon* 
 			for (int n = 0; n < TIME_TO_TICKS(maxTime); n++)
 			{
 				F::MoveSim.RunTick(moveData, absOrigin);
+				G::PredictionLines.emplace_back(absOrigin, Math::GetRotatedPosition(absOrigin, Math::VelocityToAngles(moveData.m_vecVelocity).Length2D() + 90, Vars::Visuals::SeperatorLength.Value));
 				vPredictedPos = absOrigin;
 
 				const std::optional<Vec3> aimPosition = GetAimPos(pLocal, predictor.m_pEntity, vPredictedPos);

--- a/Fedoraware/Fedoraware-TF2/src/Features/Aimbot/AimbotProjectile/AimbotProjectile.cpp
+++ b/Fedoraware/Fedoraware-TF2/src/Features/Aimbot/AimbotProjectile/AimbotProjectile.cpp
@@ -2,6 +2,7 @@
 #include "../../Vars.h"
 #include "../MovementSimulation/MovementSimulation.h"
 #include "../../Visuals/Visuals.h"
+#include "../../Backtrack/Backtrack.h"
 
 Vec3 CAimbotProjectile::Predictor_t::Extrapolate(float time)
 {
@@ -459,17 +460,18 @@ bool CAimbotProjectile::SolveProjectile(CBaseEntity* pLocal, CBaseCombatWeapon* 
 					continue;
 				}
 
-				out.m_flTime += fLatency;
+				if (out.m_flTime > TICKS_TO_TIME(n)) {
+					continue;
+				}
 
-				if (out.m_flTime < TICKS_TO_TIME(n))
+				out.m_flTime += fLatency - F::Backtrack.GetLatency();
+
+				if (WillProjectileHit(pLocal, pWeapon, pCmd, vPredictedPos, out, projInfo, predictor))
 				{
-					if (WillProjectileHit(pLocal, pWeapon, pCmd, vPredictedPos, out, projInfo, predictor))
-					{
-						G::PredictedPos = vPredictedPos;
-						F::MoveSim.Restore();
-						m_flTravelTime = out.m_flTime;
-						return true;
-					}
+					G::PredictedPos = vPredictedPos;
+					F::MoveSim.Restore();
+					m_flTravelTime = out.m_flTime;
+					return true;
 				}
 			}
 			F::MoveSim.Restore();

--- a/Fedoraware/Fedoraware-TF2/src/Features/Aimbot/MovementSimulation/MovementSimulation.cpp
+++ b/Fedoraware/Fedoraware-TF2/src/Features/Aimbot/MovementSimulation/MovementSimulation.cpp
@@ -341,7 +341,6 @@ void CMovementSimulation::RunTick(CMoveData& moveDataOut, Vec3& m_vecAbsOrigin)
 
 	I::TFGameMovement->ProcessMovement(m_pPlayer, &m_MoveData);
 
-	G::PredictionLines.emplace_back(m_MoveData.m_vecAbsOrigin, Math::GetRotatedPosition(m_MoveData.m_vecAbsOrigin, Math::VelocityToAngles(m_MoveData.m_vecVelocity).Length2D() + 90, Vars::Visuals::SeperatorLength.Value));
 
 	moveDataOut = m_MoveData;
 	m_vecAbsOrigin = m_MoveData.m_vecAbsOrigin;

--- a/Fedoraware/Fedoraware-TF2/src/Features/Auto/AutoStab/AutoStab.cpp
+++ b/Fedoraware/Fedoraware-TF2/src/Features/Auto/AutoStab/AutoStab.cpp
@@ -23,7 +23,7 @@ CBaseEntity* CAutoStab::TraceMelee(CBaseEntity* pLocal, CBaseCombatWeapon* pWeap
 {
 	const float flScale = std::min(1.0f, pLocal->m_flModelScale());
 	const float flRange = Utils::ATTRIB_HOOK_FLOAT((66.f * Vars::Triggerbot::Stab::Range.Value) * flScale, "melee_range_multiplier", pWeapon, 0, true);
-	const float flHull = Utils::ATTRIB_HOOK_FLOAT(18.f, "melee_bounds_multiplier", pWeapon, 0, true) * flScale;
+	const float flHull = 18.f * Utils::ATTRIB_HOOK_FLOAT(1.0f, "melee_bounds_multiplier", pWeapon, 0, true) * flScale;
 
 	if (flRange <= 0.0f)
 	{

--- a/Fedoraware/Fedoraware-TF2/src/Features/Backtrack/Backtrack.h
+++ b/Fedoraware/Fedoraware-TF2/src/Features/Backtrack/Backtrack.h
@@ -49,6 +49,7 @@ class CBacktrack
 	bool IsTracked(const TickRecord& record);
 	bool IsSimulationReliable(CBaseEntity* pEntity);
 	bool IsEarly(CBaseEntity* pEntity);
+	bool WithinRewindEx(const TickRecord& record, const float flCompTime);
 	//bool IsBackLagComped(CBaseEntity* pEntity);
 
 	//	utils
@@ -70,7 +71,7 @@ class CBacktrack
 	int iLastInSequence = 0;
 
 public:
-	bool WithinRewind(const TickRecord& record);
+	bool WithinRewind(const TickRecord& record, const float flDelay = 0.f);
 	bool CanHitOriginal(CBaseEntity* pEntity);
 	void PlayerHurt(CGameEvent* pEvent); //	called on player_hurt event
 	void ResolverUpdate(CBaseEntity* pEntity);	//	omfg

--- a/Fedoraware/Fedoraware-TF2/src/Features/Backtrack/Backtrack.h
+++ b/Fedoraware/Fedoraware-TF2/src/Features/Backtrack/Backtrack.h
@@ -57,7 +57,6 @@ class CBacktrack
 	std::optional<TickRecord> GetHitRecord(CUserCmd* pCmd, CBaseEntity* pEntity, Vec3 vAngles, Vec3 vPos);
 	//	utils - fake latency
 	void UpdateDatagram();
-	float GetLatency();
 
 	//	data
 	std::unordered_map<CBaseEntity*, std::deque<TickRecord>> mRecords;
@@ -70,6 +69,7 @@ class CBacktrack
 	int iLastInSequence = 0;
 
 public:
+	float GetLatency();
 	inline bool IsTracked(const TickRecord& record, const float flDelay = 0.f);
 	bool WithinRewind(const TickRecord& record, const float flDelay = I::GlobalVars->interval_per_tick);
 	bool CanHitOriginal(CBaseEntity* pEntity);

--- a/Fedoraware/Fedoraware-TF2/src/Features/Backtrack/Backtrack.h
+++ b/Fedoraware/Fedoraware-TF2/src/Features/Backtrack/Backtrack.h
@@ -46,9 +46,8 @@ class CBacktrack
 	const Color_t BT_LOG_COLOUR{ 150, 0, 212, 255};
 
 //	logic
-	bool IsTracked(const TickRecord& record);
 	bool IsSimulationReliable(CBaseEntity* pEntity);
-	bool IsEarly(CBaseEntity* pEntity);
+	inline bool IsEarly(CBaseEntity* pEntity);
 	bool WithinRewindEx(const TickRecord& record, const float flCompTime);
 	//bool IsBackLagComped(CBaseEntity* pEntity);
 
@@ -71,7 +70,8 @@ class CBacktrack
 	int iLastInSequence = 0;
 
 public:
-	bool WithinRewind(const TickRecord& record, const float flDelay = 0.f);
+	inline bool IsTracked(const TickRecord& record, const float flDelay = 0.f);
+	bool WithinRewind(const TickRecord& record, const float flDelay = I::GlobalVars->interval_per_tick);
 	bool CanHitOriginal(CBaseEntity* pEntity);
 	void PlayerHurt(CGameEvent* pEvent); //	called on player_hurt event
 	void ResolverUpdate(CBaseEntity* pEntity);	//	omfg

--- a/Fedoraware/Fedoraware-TF2/src/Features/ESP/ESP.cpp
+++ b/Fedoraware/Fedoraware-TF2/src/Features/ESP/ESP.cpp
@@ -1503,9 +1503,9 @@ bool InCond(CBaseEntity* pEntity, int eCond)
 std::vector<std::wstring> CESP::GetPlayerConds(CBaseEntity* pEntity) const
 {
 	std::vector<std::wstring> szCond{};
-	const int nCond = pEntity->GetCond();
-	const int nCondEx = pEntity->GetCondEx();
-	const int nFlag = pEntity->GetFlags();
+	const int& nCond = pEntity->GetCond();
+	const int& nCondEx = pEntity->GetCondEx();
+	const int& nFlag = pEntity->GetFlags();
 
 	{
 		const float flTickVelSqr = pow(pEntity->TickVelocity2D(), 2);
@@ -1515,11 +1515,6 @@ std::vector<std::wstring> CESP::GetPlayerConds(CBaseEntity* pEntity) const
 	if (const wchar_t* rune = pEntity->GetRune())
 	{	// I want to see if they are the king before anything else.
 		szCond.emplace_back(rune);
-	}
-
-	if (pEntity->GetDormant())
-	{
-		szCond.emplace_back(L"Dormant");
 	}
 
 	if (InCond(pEntity, 61))
@@ -1557,6 +1552,11 @@ std::vector<std::wstring> CESP::GetPlayerConds(CBaseEntity* pEntity) const
 	if (pEntity->GetHealth() > pEntity->GetMaxHealth())
 	{
 		szCond.emplace_back(L"Overhealed");
+	}
+
+	if (nCondEx & TFCondEx2_BlastJumping)
+	{
+		szCond.emplace_back(L"Blast Jumping");
 	}
 
 	if (nCond & TFCond_OnFire)

--- a/Fedoraware/Fedoraware-TF2/src/Features/ESP/ESP.cpp
+++ b/Fedoraware/Fedoraware-TF2/src/Features/ESP/ESP.cpp
@@ -1505,6 +1505,7 @@ std::vector<std::wstring> CESP::GetPlayerConds(CBaseEntity* pEntity) const
 	std::vector<std::wstring> szCond{};
 	const int& nCond = pEntity->GetCond();
 	const int& nCondEx = pEntity->GetCondEx();
+	const int& nCondEx2 = pEntity->GetCondEx2();
 	const int& nFlag = pEntity->GetFlags();
 
 	{
@@ -1554,7 +1555,7 @@ std::vector<std::wstring> CESP::GetPlayerConds(CBaseEntity* pEntity) const
 		szCond.emplace_back(L"Overhealed");
 	}
 
-	if (nCondEx & TFCondEx2_BlastJumping)
+	if (nCondEx2 & TFCondEx2_BlastJumping)
 	{
 		szCond.emplace_back(L"Blast Jumping");
 	}

--- a/Fedoraware/Fedoraware-TF2/src/SDK/Main/BaseCombatWeapon/BaseCombatWeapon.h
+++ b/Fedoraware/Fedoraware-TF2/src/SDK/Main/BaseCombatWeapon/BaseCombatWeapon.h
@@ -18,6 +18,8 @@ namespace S
 	MAKE_SIGNATURE(CBaseCombatWeapon_GetTFWeaponInfo, CLIENT_DLL, "55 8B EC FF 75 ? E8 ? ? ? ? 83 C4 ? 85 C0 75 ? 5D C3", 0x0);
 	MAKE_SIGNATURE(CBaseCombatWeapon_GetWeaponSpread, CLIENT_DLL, "55 8B EC 83 EC ? 56 8B F1 57 6A ? 6A", 0x0);
 
+	MAKE_SIGNATURE(CTFWeaponBaseMelee_DoSwingTraceInternal, CLIENT_DLL, "53 8B DC 83 EC ? 83 E4 ? 83 C4 ? 55 8B 6B ? 89 6C 24 ? 8B EC 81 EC ? ? ? ? A1 ? ? ? ? 56 8B F1", 0x0);
+
 	MAKE_SIGNATURE(CBaseCombatWeapon_GetSpreadAngles, CLIENT_DLL, "55 8B EC 83 EC ? 56 57 6A ? 68 ? ? ? ? 68 ? ? ? ? 6A ? 8B F9 E8 ? ? ? ? 50 E8 ? ? ? ? 8B F0 83 C4 ? 85 F6", 0x0);
 	MAKE_SIGNATURE(CBaseCombatWeapon_GetProjectileFireSetup, CLIENT_DLL, "53 8B DC 83 EC ? 83 E4 ? 83 C4 ? 55 8B 6B ? 89 6C 24 ? 8B EC 81 EC ? ? ? ? 56 8B F1 57 8B 06 8B 80 ? ? ? ? FF D0 84 C0", 0x0);
 
@@ -223,6 +225,12 @@ public: //Everything else, lol
 	__inline bool DoSwingTrace(CGameTrace& Trace)
 	{
 		return GetVFunc<int(__thiscall*)(CGameTrace&)>(this, 454)(Trace);
+	}
+
+	__inline bool DoSwingTraceInternal(CGameTrace& Trace)
+	{
+		static auto fnDoSwingTraceInternal = S::CTFWeaponBaseMelee_DoSwingTraceInternal.As<bool(__thiscall*)(decltype(this), CGameTrace&, bool, void*)>();
+		return fnDoSwingTraceInternal(this, Trace, false, nullptr);
 	}
 
 	__inline int LookupAttachment(const char* pAttachmentName)

--- a/Fedoraware/Fedoraware-TF2/src/SDK/Main/ConVars/ConVars.cpp
+++ b/Fedoraware/Fedoraware-TF2/src/SDK/Main/ConVars/ConVars.cpp
@@ -29,19 +29,6 @@ void CConVars::Init()
 		constexpr int FCVAR_NOT_CONNECTED = (int)EConVarFlags::FCVAR_NOT_CONNECTED;
 		cmdBase->m_nFlags &= ~(FCVAR_HIDDEN | FCVAR_DEVELOPMENT_ONLY | FCVAR_CHEAT | FCVAR_NOT_CONNECTED);
 
-
-		if (ConVar* convar = reinterpret_cast<ConVar*>(cmdBase))
-		{
-			if (convar->GetName() == "name")
-			{
-				convar->m_fnChangeCallback = 0;
-				convar->InternalSetValue(0);
-				convar->m_fnChangeCallback = 0;
-			}
-			cvarMap[FNV1A::HashConst(convar->GetName())] = convar;
-
-		}
-
 		cmdBase = cmdBase->m_pNext;
 	}
 }


### PR DESCRIPTION
- While it's still not great, this feels significantly better than the previous melee aimbot.
- Did major cleanup to the melee aimbot code
- Corrected timing for backtrack functions when used by melee aimbot
- Removed cheap imitation and switched to using games function
- Fixed a possible issue relating to hullsizes and ranges changing as player size changes
- Stopped movesimming enemies in melee aimbot as it was stupid
- Moved movesim lines to be recorded in projectile aimbot as many other things are now using movesim
- Fixed an issue with dragons fury and timed weapons not firing at high latency, as well as projectile aimbot oversimulating targets if fake latency was enabled.