### PR TITLE
Change Fakelag key to a toggle instead of on hold

### DIFF
--- a/Fedoraware/Fedoraware-TF2/src/Features/AntiHack/FakeLag/FakeLag.cpp
+++ b/Fedoraware/Fedoraware-TF2/src/Features/AntiHack/FakeLag/FakeLag.cpp
@@ -73,7 +73,7 @@ bool CFakeLag::IsAllowed(CBaseEntity* pLocal)
 		return true;
 	}	//	no other checks, we want this
 
-	// Is a fakelag key set and pressed?
+	// Could put this in a better place but lazy
 	static KeyHelper fakelagKey{ &Vars::Misc::CL_Move::FakelagKey.Value };
 	Vars::Misc::CL_Move::Fakelag.Value = (fakelagKey.Pressed() ? !Vars::Misc::CL_Move::Fakelag.Value : Vars::Misc::CL_Move::Fakelag.Value);
 

--- a/Fedoraware/Fedoraware-TF2/src/Features/AntiHack/FakeLag/FakeLag.cpp
+++ b/Fedoraware/Fedoraware-TF2/src/Features/AntiHack/FakeLag/FakeLag.cpp
@@ -75,10 +75,8 @@ bool CFakeLag::IsAllowed(CBaseEntity* pLocal)
 
 	// Is a fakelag key set and pressed?
 	static KeyHelper fakelagKey{ &Vars::Misc::CL_Move::FakelagKey.Value };
-	if (!fakelagKey.Down() && Vars::Misc::CL_Move::FakelagOnKey.Value)
-	{
-		return false;
-	}
+	Vars::Misc::CL_Move::Fakelag.Value = (fakelagKey.Pressed() ? !Vars::Misc::CL_Move::Fakelag.Value : Vars::Misc::CL_Move::Fakelag.Value);
+
 
 	// Do we have enough velocity for velocity mode?
 	if (Vars::Misc::CL_Move::WhileMoving.Value && pLocal->GetVecVelocity().Length2D() < 10.f)

--- a/Fedoraware/Fedoraware-TF2/src/Features/Menu/Menu.cpp
+++ b/Fedoraware/Fedoraware-TF2/src/Features/Menu/Menu.cpp
@@ -1545,11 +1545,8 @@ void CMenu::MenuHvH()
 			/* Section: Fakelag */
 			SectionTitle("Fakelag");
 			WToggle("Enable Fakelag", &Vars::Misc::CL_Move::Fakelag.Value);
-			MultiCombo({ "While Moving", "On Key", "While Visible", "Predict Visibility", "While Unducking", "While Airborne" }, { &Vars::Misc::CL_Move::WhileMoving.Value, &Vars::Misc::CL_Move::FakelagOnKey.Value, &Vars::Misc::CL_Move::WhileVisible.Value, &Vars::Misc::CL_Move::PredictVisibility.Value, &Vars::Misc::CL_Move::WhileUnducking.Value, &Vars::Misc::CL_Move::WhileInAir.Value }, "Flags###FakeLagFlags");
-			if (Vars::Misc::CL_Move::FakelagOnKey.Value)
-			{
-				InputKeybind("Fakelag key", Vars::Misc::CL_Move::FakelagKey); HelpMarker("The key to activate fakelag as long as it's held");
-			}
+			MultiCombo({ "While Moving", "On Key", "While Visible", "Predict Visibility", "While Unducking", "While Airborne" }, { &Vars::Misc::CL_Move::WhileMoving.Value, &Vars::Misc::CL_Move::WhileVisible.Value, &Vars::Misc::CL_Move::PredictVisibility.Value, &Vars::Misc::CL_Move::WhileUnducking.Value, &Vars::Misc::CL_Move::WhileInAir.Value }, "Flags###FakeLagFlags");
+			InputKeybind("Fakelag Toggle Key", Vars::Misc::CL_Move::FakelagKey); HelpMarker("The key to toggle fakelag.");
 			WCombo("Fakelag Mode###FLmode", &Vars::Misc::CL_Move::FakelagMode.Value, { "Plain", "Random", "Adaptive" }); HelpMarker("Controls how fakelag will be controlled.");
 
 			switch (Vars::Misc::CL_Move::FakelagMode.Value)
@@ -2435,7 +2432,7 @@ void CMenu::DrawKeybinds()
 		drawOption("Auto Shoot", Vars::Aimbot::Global::AutoShoot.Value);
 		drawOption("Double Tap", isActive(Vars::Misc::CL_Move::DTMode.Value != 3, Vars::Misc::CL_Move::DTMode.Value == 0, Vars::Misc::CL_Move::DoubletapKey.Value));
 		drawOption("Anti Aim", Vars::AntiHack::AntiAim::Active.Value);
-		drawOption("Fakelag", isActive(Vars::Misc::CL_Move::Fakelag.Value, Vars::Misc::CL_Move::FakelagOnKey.Value, Vars::Misc::CL_Move::FakelagKey.Value));
+		drawOption("Fakelag", isActive(Vars::Misc::CL_Move::Fakelag.Value, Vars::Misc::CL_Move::FakelagKey.Value));
 		drawOption("Triggerbot", isActive(Vars::Triggerbot::Global::Active.Value, Vars::Triggerbot::Global::TriggerKey.Value, Vars::Triggerbot::Global::TriggerKey.Value));
 	}
 

--- a/Fedoraware/Fedoraware-TF2/src/Features/Vars.h
+++ b/Fedoraware/Fedoraware-TF2/src/Features/Vars.h
@@ -796,7 +796,6 @@ namespace Vars
 		CVar(WhileInAir, false)
 		CVar(FakelagMin, 1) //	only show when FakelagMode=2
 		CVar(FakelagMax, 22)
-		CVar(FakelagOnKey, false) // dont show when fakelagmode=2|3
 		CVar(FakelagKey, 0x54) //T
 		CVar(FakelagValue, 1) // dont show when fakelagmode=2
 		CVar(AutoPeekKey, 0)


### PR DESCRIPTION
### Discussed in https://github.com/Fedoraware/Fedoraware/discussions/1084

<div type='discussions-op-text'>

<sup>Originally posted by **Ragdoll117** October  7, 2023</sup>
Instead of the key being held, do a toggle like nullcore and the keybind toggling off the fakelag masterswitch</div>
I agree with this change.
Should work.