### PR TITLE
Fixed Attribute Changer not working on Sniper rifle

### DIFF
--- a/Fedoraware/Fedoraware-TF2/src/Features/Items/AttributeChanger/AttributeChanger.cpp
+++ b/Fedoraware/Fedoraware-TF2/src/Features/Items/AttributeChanger/AttributeChanger.cpp
@@ -35,11 +35,7 @@ void CAttributeChanger::Run()
 			if (const auto& pWeapon = reinterpret_cast<CBaseCombatWeapon*>(I::ClientEntityList->GetClientEntityFromHandle(myWeapons[n])))
 			{
 				const auto pList = reinterpret_cast<CAttributeList*>(pWeapon + 0x9C4);
-				if (!pList || pList->m_Attributes.Count() > 0)
-				{
-					continue;
-				}
-
+	
 				const auto nIndex = pWeapon->GetItemDefIndex();
 				if (AttributeMap.find(nIndex) != AttributeMap.end())
 				{

--- a/Fedoraware/Fedoraware-TF2/src/Features/Items/AttributeChanger/AttributeChanger.cpp
+++ b/Fedoraware/Fedoraware-TF2/src/Features/Items/AttributeChanger/AttributeChanger.cpp
@@ -35,6 +35,9 @@ void CAttributeChanger::Run()
 			if (const auto& pWeapon = reinterpret_cast<CBaseCombatWeapon*>(I::ClientEntityList->GetClientEntityFromHandle(myWeapons[n])))
 			{
 				const auto pList = reinterpret_cast<CAttributeList*>(pWeapon + 0x9C4);
+				if (!pList) {
+					continue;
+				}
 	
 				const auto nIndex = pWeapon->GetItemDefIndex();
 				if (AttributeMap.find(nIndex) != AttributeMap.end())


### PR DESCRIPTION
Turns out the Sniper Rifle has more than 1 attribute which didn't let us change it