### PR TITLE
SSE2 & PE header eraser

### DIFF
--- a/Fedoraware/Fedoraware-TF2/Fedoraware-TF2.vcxproj
+++ b/Fedoraware/Fedoraware-TF2/Fedoraware-TF2.vcxproj
@@ -103,7 +103,7 @@
       <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
       <BufferSecurityCheck>false</BufferSecurityCheck>
       <FloatingPointModel>Precise</FloatingPointModel>
-      <EnableEnhancedInstructionSet>NotSet</EnableEnhancedInstructionSet>
+      <EnableEnhancedInstructionSet>StreamingSIMDExtensions2</EnableEnhancedInstructionSet>
       <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
@@ -146,7 +146,7 @@
       <ConformanceMode>true</ConformanceMode>
       <LanguageStandard>stdcpp20</LanguageStandard>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <EnableEnhancedInstructionSet>NotSet</EnableEnhancedInstructionSet>
+      <EnableEnhancedInstructionSet>StreamingSIMDExtensions2</EnableEnhancedInstructionSet>
       <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>

--- a/Fedoraware/Fedoraware-TF2/src/DllMain.cpp
+++ b/Fedoraware/Fedoraware-TF2/src/DllMain.cpp
@@ -2,31 +2,6 @@
 #include "Core/Core.h"
 #include "Utils/Minidump/Minidump.h"
 
-void RemovePEH(HINSTANCE hinstDLL)
-{
-	const auto pImageDOS = reinterpret_cast<PIMAGE_DOS_HEADER>(hinstDLL);
-
-	// Was the header already manipulated?
-	if (pImageDOS->e_magic != IMAGE_DOS_SIGNATURE)
-	{
-		return;
-	}
-
-	const auto pImageNT = reinterpret_cast<PIMAGE_NT_HEADERS>(pImageDOS + pImageDOS->e_lfanew);
-	const auto sizeOfPe = pImageNT->FileHeader.SizeOfOptionalHeader;
-
-	if (pImageNT->Signature == IMAGE_NT_SIGNATURE && sizeOfPe)
-	{
-		const auto headerSize = static_cast<size_t>(sizeOfPe);
-		DWORD dwProtect = 0x0;
-
-		// Zero out the header
-		VirtualProtect(hinstDLL, headerSize, PAGE_EXECUTE_READWRITE, &dwProtect);
-		RtlZeroMemory(hinstDLL, headerSize);
-		VirtualProtect(hinstDLL, headerSize, dwProtect, &dwProtect);
-	}
-}
-
 DWORD WINAPI MainThread(LPVOID lpParam)
 {
 	//"mss32.dll" being one of the last modules to be loaded
@@ -64,8 +39,6 @@ BOOL WINAPI DllMain(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpvReserved)
 		SetUnhandledExceptionFilter(Minidump::ExceptionFilter);
 #endif
 
-		RemovePEH(hinstDLL);
-		DisableThreadLibraryCalls(hinstDLL);
 		if (const auto hMainThread = CreateThread(nullptr, 0, MainThread, hinstDLL, 0, nullptr))
 		{
 			CloseHandle(hMainThread);

--- a/Fedoraware/Fedoraware-TF2/src/Utils/Pattern/Pattern.cpp
+++ b/Fedoraware/Fedoraware-TF2/src/Utils/Pattern/Pattern.cpp
@@ -8,8 +8,9 @@ DWORD CPattern::FindPattern(DWORD dwAddress, DWORD dwSize, LPCSTR szPattern)
 {
 	auto szPat = szPattern;
 	DWORD dwFirstMatch = 0x0;
+	const DWORD dwEnd = dwAddress + dwSize - strlen(szPattern);
 
-	for (auto pCur = dwAddress; pCur < dwAddress + dwSize; pCur++)
+	for (auto pCur = dwAddress; pCur < dwEnd; pCur++)
 	{
 		if (!*szPat)
 		{


### PR DESCRIPTION
- Enabled SSE2 instructions since nearly 100% of CPUs should support it according to [Steam Hardware Survey](https://store.steampowered.com/hwsurvey/Steam-Hardware-Software-Survey-Welcome-to-Steam).
- Removed PE header eraser as it should be done by the injector